### PR TITLE
FEAT: add Python lint and test workflow for pull requests and pushes

### DIFF
--- a/.github/workflows/python-lint-test.yml
+++ b/.github/workflows/python-lint-test.yml
@@ -8,6 +8,12 @@ on:
       - "main"
     paths:
       - "**/*.py"
+  workflow_dispatch:
+    inputs:
+      target_dir:
+        description: "Directories to run lint and test on"
+        required: true
+        default: ""
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -20,6 +26,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Get changed directories
         id: changes
+        if: ${{ inputs.target_dir == '' }}
         run: |
           # Get unique directories from changed files
           if [ "${{ github.event_name }}" == "pull_request" ]; then

--- a/.github/workflows/python-lint-test.yml
+++ b/.github/workflows/python-lint-test.yml
@@ -12,7 +12,7 @@ on:
     inputs:
       target_dir:
         description: "Directories to run lint and test on"
-        required: true
+        required: false
         default: ""
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/python-lint-test.yml
+++ b/.github/workflows/python-lint-test.yml
@@ -26,8 +26,14 @@ jobs:
         uses: actions/checkout@v4
       - name: Get changed directories
         id: changes
-        if: ${{ inputs.target_dir == '' }}
         run: |
+          # Check if the target_dir input is provided
+          if [ -n "${{ github.event.inputs.target_dir }}" ]; then
+            echo "dirs=${{ github.event.inputs.target_dir }}" >> $GITHUB_OUTPUT
+            echo "run_tests=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           # Get unique directories from changed files
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             # For PRs, compare with base branch


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for Python linting and testing. The primary changes involve renaming the workflow file and adding support for manual workflow dispatch with input parameters.

Improvements to GitHub Actions workflow:

* `.github/workflows/python-lint.yml` was renamed to `.github/workflows/python-lint-test.yml`.
* Added `workflow_dispatch` event to allow manual triggering of the workflow with an input parameter `target_dir` to specify directories for linting and testing.
* Updated the `jobs` section to check if the `target_dir` input is provided and set corresponding outputs and flags for running tests based on the input.## Summary
- FEAT: add Python lint and test workflow for pull requests and pushes
