### PR TITLE
fix: refactor Python lint workflow to dynamically determine target projects and streamline directory handling

### DIFF
--- a/.github/workflows/python-lint-test.yml
+++ b/.github/workflows/python-lint-test.yml
@@ -1,4 +1,5 @@
 name: Python Lint and Test
+
 on:
   pull_request:
     paths:
@@ -10,82 +11,92 @@ on:
       - "**/*.py"
   workflow_dispatch:
     inputs:
-      target_dir:
-        description: "Directories to run lint and test on"
+      target_projects:
+        description: "Projects to run lint and test on"
         required: false
         default: ""
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  python-lint-and-test:
+  target_projects:
+    name: Find target Projects
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
+    outputs:
+      projects: ${{ steps.get-projects.outputs.projects }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # FIXME: fetch all history for all branches and tags
+          fetch-depth: 0
       - name: Get changed directories
-        id: changes
+        id: changed-files
+        uses: tj-actions/changed-files@6cb76d07bee4c9772c6882c06c37837bf82a04d3 # v46
+        with:
+          matrix: true # 後続のjobでmatrixで使うために。ファイルがjson形式で出力される
+          dir_names: true # uniqueディレクトリ名を取得
+          dir_names_max_depth: 1 # ディレクトリ名の深さを指定
+          files_ignore: |
+            .github/**
+      - name: Get Python projects
+        uses: actions/github-script@v7
+        id: get-projects
+        with:
+          script: |
+            const fs = require('node:fs');
+            // If target_projects input is provided, use it
+            dispatch_inputs = "${{ github.event.inputs.target_projects }}";
+            if (dispatch_inputs !== "") {
+              dispatch_inputs = dispatch_inputs.split(',').map(path => path.trim());
+              core.setOutput('projects', JSON.stringify(dispatch_inputs));
+            } else { // If no input is provided, get directories from changed files
+              const inputs = JSON.parse(${{ toJSON(steps.changed-files.outputs.all_changed_and_modified_files) }});
+              // Filter out directories that contain pyproject.toml and Makefile
+              const paths = inputs.filter(path => {
+                if (
+                  fs.statSync(path).isDirectory()
+                  && fs.existsSync(`${path}/pyproject.toml`)
+                  && fs.existsSync(`${path}/Makefile`)
+                ) {
+                  return true;
+                }
+                return false;
+              });
+              core.setOutput('projects', JSON.stringify(paths));
+            }
+      - name: Print changed directories
         run: |
-          # Check if the target_dir input is provided
-          if [ -n "${{ github.event.inputs.target_dir }}" ]; then
-            echo "wd=${{ github.event.inputs.target_dir }}" >> $GITHUB_OUTPUT
-            echo "should_run=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
+          echo "Changed directories: ${{ steps.get-projects.outputs.projects }}"
+          echo "::debug::Changed directories: ${{ steps.get-projects.outputs.projects }}"
 
-          # Get unique directories from changed files
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            # For PRs, compare with base branch
-            git fetch origin ${{ github.base_ref }}
-            CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep '\.py$' || echo "")
-          else
-            # For pushes, compare with previous commit
-            CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.py$' || echo "")
-          fi
-          echo "::debug::Changed files: $CHANGED_FILES"
-
-          # If no Python files changed, skip tests
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "No Python files changed"
-            echo "should_run=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          CHANGED_DIRS=$(echo "$CHANGED_FILES" | awk -F/ '{print $1}' | sort -u)
-          echo "Changed directories: $CHANGED_DIRS"
-
-          # Count how many directories were changed
-          DIR_COUNT=$(echo "$CHANGED_DIRS" | grep -v "^$" | wc -l)
-
-          if [ "$DIR_COUNT" -eq 0 ]; then
-            echo "No Python directories changed"
-            echo "should_run=false" >> $GITHUB_OUTPUT
-            exit 0
-          elif [ "$DIR_COUNT" -gt 1 ]; then
-            echo "::error::Changes detected in multiple directories: $CHANGED_DIRS"
-            echo "This workflow supports changes in only one directory at a time"
-            exit 1
-          fi
-
-          # Set the single directory as output
-          echo "wd=$(echo "$CHANGED_DIRS" | tr -d '\n')" >> $GITHUB_OUTPUT
-          echo "should_run=true" >> $GITHUB_OUTPUT
+  python-lint-and-test:
+    name: Python Lint and Test
+    needs: target_projects
+    if: ${{ needs.target_projects.outputs.projects != '' && toJson(fromJson(needs.target_projects.outputs.projects)) != '[]' }}
+    strategy:
+      matrix:
+        project: ${{ fromJson(needs.target_projects.outputs.projects) }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.project }}
+      cancel-in-progress: true
+    defaults:
+      run:
+        working-directory: ${{ matrix.project }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Install uv
-        if: ${{ steps.changes.outputs.should_run }} == 'true'
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
       - name: Install the project
-        if: ${{ steps.changes.outputs.should_run }} == 'true'
         run: make install
-        working-directory: ${{ steps.changes.outputs.wd }}
       - name: Lint
-        if: ${{ steps.changes.outputs.should_run }} == 'true'
         run: make lint
-        working-directory: ${{ steps.changes.outputs.wd }}
       - name: Test
-        if: ${{ steps.changes.outputs.should_run }} == 'true'
         run: make test
-        working-directory: ${{ steps.changes.outputs.wd }}


### PR DESCRIPTION
## Summary
- fix: refactor Python lint workflow to dynamically determine target projects and streamline directory handling
This pull request includes significant updates to the GitHub Actions workflow for Python linting and testing. The changes aim to improve the flexibility and efficiency of the workflow by introducing a new job to dynamically determine the target projects based on the changes in the pull request.

Key updates to the GitHub Actions workflow:

* [`.github/workflows/python-lint-test.yml`](diffhunk://#diff-db87be0af3a2cef6a2dece690dd0b323d1fd3abb72c3ff949ad44c83679f4dc3L13-L91): Replaced the `target_dir` input with `target_projects` to specify the projects to run lint and test on.
* [`.github/workflows/python-lint-test.yml`](diffhunk://#diff-db87be0af3a2cef6a2dece690dd0b323d1fd3abb72c3ff949ad44c83679f4dc3L13-L91): Added a new job `target_projects` to find the target projects by checking for changes in directories containing `pyproject.toml` and `Makefile`.
* [`.github/workflows/python-lint-test.yml`](diffhunk://#diff-db87be0af3a2cef6a2dece690dd0b323d1fd3abb72c3ff949ad44c83679f4dc3L13-L91): Updated the main `python-lint-and-test` job to depend on the `target_projects` job and use a matrix strategy to run lint and test on each project found.
* [`.github/workflows/python-lint-test.yml`](diffhunk://#diff-db87be0af3a2cef6a2dece690dd0b323d1fd3abb72c3ff949ad44c83679f4dc3L13-L91): Removed the old logic for determining changed directories and replaced it with a step to print the changed directories based on the output of the `target_projects` job.
* [`.github/workflows/python-lint-test.yml`](diffhunk://#diff-db87be0af3a2cef6a2dece690dd0b323d1fd3abb72c3ff949ad44c83679f4dc3L13-L91): Simplified the steps for installing dependencies, linting, and testing by removing unnecessary condition checks and using the matrix strategy.