### PR TITLE
refactor: remove Dockerfile and update Makefile to streamline job runner commands

### DIFF
--- a/job_runner/samples/Dockerfile
+++ b/job_runner/samples/Dockerfile
@@ -1,3 +1,0 @@
-FROM --platform="linux/amd64" ubuntu:24.10
-
-CMD [ "echo" , "This is the sample of ml-sandbox/job_runner" ]

--- a/job_runner/samples/Makefile
+++ b/job_runner/samples/Makefile
@@ -5,10 +5,6 @@ help: ## Show options
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build
-build: ## Build the Docker
-	docker image build -t us-docker.pkg.dev/haru256-ml-sandbox/ml-sandbox/job_runner:latest .
-
-.PHONY: push
-push: ## Push the Docker
-	docker push us-docker.pkg.dev/haru256-ml-sandbox/ml-sandbox/job_runner:latest
+.PHONY: run
+run: ## run the job runner
+	uv run job-runner

--- a/job_runner/src/job_runner/main.py
+++ b/job_runner/src/job_runner/main.py
@@ -33,8 +33,8 @@ class JobRunner(BaseSettings):
 
     # from args
     command: Optional[str] = Field(default=None, description="Command to run in the container")
-    machine_type: Literal["g2-instance-4", "g2-instance-8"] = Field(
-        description="Machine type to use for the job", default="g2-instance-4"
+    machine_type: Literal["g2-standard-4", "g2-standard-8"] = Field(
+        description="Machine type to use for the job", default="g2-standard-4"
     )
     accelerator_type: Literal["NVIDIA_L4"] = Field(
         description="Accelerator type to use for the job", default="NVIDIA_L4"


### PR DESCRIPTION
This pull request includes several changes to the `job_runner` module, focusing on updating configurations, modifying build and push commands, and changing the machine type options. The most important changes include removing the Dockerfile, updating the `Makefile` to replace build and push commands with a run command, and modifying the machine type literals in the `main.py` file.

Configuration updates:

* [`job_runner/samples/Dockerfile`](diffhunk://#diff-902a32ce0c0c251af8168fc2be114326f847e9d580def646de4b1c0da4834b55L1-L3): Removed the Dockerfile which previously specified the base image and command for the job runner.

Build and run commands:

* [`job_runner/samples/Makefile`](diffhunk://#diff-c71adcb9402152c164201ccc1a77c5ec6a9b338f644c546affc1c4c6004b4a84L8-R10): Removed the build and push commands and replaced them with a run command to execute the job runner.

Machine type options:

* [`job_runner/src/job_runner/main.py`](diffhunk://#diff-dd538f74b39a1046dd6167a6b58c7d0d111d18b371d0b6ba5b3946ecf4d2d13eL36-R37): Updated the `machine_type` literals to use "g2-standard-4" and "g2-standard-8" instead of "g2-instance-4" and "g2-instance-8".