### PR TITLE
Create Dataset for Sequential Recommendation

### DIFF
--- a/ml_sandbox_libs/samples/amazon_reviews_2023.ipynb
+++ b/ml_sandbox_libs/samples/amazon_reviews_2023.ipynb
@@ -26,7 +26,7 @@
     "import pathlib\n",
     "\n",
     "from ml_sandbox_libs.data.amazon_reviews_dataset import (\n",
-    "    AmazonReviewsDataModule,\n",
+    "    AmazonReviewsSeqRecDataModule,\n",
     "    fetch_dataset,\n",
     "    fetch_metadata,\n",
     ")"
@@ -42,7 +42,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2025-04-12 08:46:02.554\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mml_sandbox_libs.data.amazon_reviews_dataset\u001b[0m:\u001b[36mfetch_dataset\u001b[0m:\u001b[36m41\u001b[0m - \u001b[1mFetching Amazon Reviews 2023 dataset\u001b[0m\n"
+      "\u001b[32m2025-04-12 22:24:42.803\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mml_sandbox_libs.data.amazon_reviews_dataset\u001b[0m:\u001b[36mfetch_dataset\u001b[0m:\u001b[36m41\u001b[0m - \u001b[1mFetching Amazon Reviews 2023 dataset\u001b[0m\n"
      ]
     },
     {
@@ -131,7 +131,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2025-04-12 08:46:05.708\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mml_sandbox_libs.data.amazon_reviews_dataset\u001b[0m:\u001b[36mfetch_metadata\u001b[0m:\u001b[36m61\u001b[0m - \u001b[1mFetching Amazon Reviews 2023 metadata\u001b[0m\n"
+      "\u001b[32m2025-04-12 22:24:46.465\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mml_sandbox_libs.data.amazon_reviews_dataset\u001b[0m:\u001b[36mfetch_metadata\u001b[0m:\u001b[36m61\u001b[0m - \u001b[1mFetching Amazon Reviews 2023 metadata\u001b[0m\n"
      ]
     },
     {
@@ -214,12 +214,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2025-04-12 08:46:07.369\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mml_sandbox_libs.data.amazon_reviews_dataset\u001b[0m:\u001b[36mprepare_data\u001b[0m:\u001b[36m488\u001b[0m - \u001b[1mLoading preprocessed dataset\u001b[0m\n"
+      "\u001b[32m2025-04-12 22:24:48.163\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mml_sandbox_libs.data.amazon_reviews_dataset\u001b[0m:\u001b[36mprepare_data\u001b[0m:\u001b[36m484\u001b[0m - \u001b[1mLoading preprocessed dataset\u001b[0m\n"
      ]
     }
    ],
    "source": [
-    "datamodule = AmazonReviewsDataModule(\n",
+    "datamodule = AmazonReviewsSeqRecDataModule(\n",
     "    save_dir=pathlib.Path(\"../data\"),\n",
     "    batch_size=2,\n",
     "    num_workers=4,\n",
@@ -305,12 +305,12 @@
     {
      "data": {
       "text/plain": [
-       "(tensor([229547,  57218]),\n",
-       " tensor([21182,  7538]),\n",
+       "(tensor([208759,  18002]),\n",
+       " tensor([34981, 72702]),\n",
        " tensor([[51862, 14281],\n",
-       "         [42119, 49773]]),\n",
-       " tensor([[    0,     0,     0,     0, 21774],\n",
-       "         [    0,     0,     0,     0,  3984]]))"
+       "         [42118, 49772]]),\n",
+       " tensor([[    0,     0,     0,     0, 26395],\n",
+       "         [    0,     0,     0,     0,     0]]))"
       ]
      },
      "execution_count": 8,

--- a/ml_sandbox_libs/samples/amazon_reviews_2023.ipynb
+++ b/ml_sandbox_libs/samples/amazon_reviews_2023.ipynb
@@ -42,7 +42,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2025-04-12 22:24:42.803\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mml_sandbox_libs.data.amazon_reviews_dataset\u001b[0m:\u001b[36mfetch_dataset\u001b[0m:\u001b[36m41\u001b[0m - \u001b[1mFetching Amazon Reviews 2023 dataset\u001b[0m\n"
+      "\u001b[32m2025-04-19 20:08:09.182\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mml_sandbox_libs.data.amazon_reviews_dataset\u001b[0m:\u001b[36mfetch_dataset\u001b[0m:\u001b[36m41\u001b[0m - \u001b[1mFetching Amazon Reviews 2023 dataset\u001b[0m\n"
      ]
     },
     {
@@ -131,7 +131,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2025-04-12 22:24:46.465\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mml_sandbox_libs.data.amazon_reviews_dataset\u001b[0m:\u001b[36mfetch_metadata\u001b[0m:\u001b[36m61\u001b[0m - \u001b[1mFetching Amazon Reviews 2023 metadata\u001b[0m\n"
+      "\u001b[32m2025-04-19 20:08:14.308\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mml_sandbox_libs.data.amazon_reviews_dataset\u001b[0m:\u001b[36mfetch_metadata\u001b[0m:\u001b[36m61\u001b[0m - \u001b[1mFetching Amazon Reviews 2023 metadata\u001b[0m\n"
      ]
     },
     {
@@ -214,7 +214,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2025-04-12 22:24:48.163\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mml_sandbox_libs.data.amazon_reviews_dataset\u001b[0m:\u001b[36mprepare_data\u001b[0m:\u001b[36m484\u001b[0m - \u001b[1mLoading preprocessed dataset\u001b[0m\n"
+      "\u001b[32m2025-04-19 20:08:16.901\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mml_sandbox_libs.data.amazon_reviews_dataset\u001b[0m:\u001b[36mprepare_data\u001b[0m:\u001b[36m484\u001b[0m - \u001b[1mLoading preprocessed dataset\u001b[0m\n"
      ]
     }
    ],
@@ -305,12 +305,12 @@
     {
      "data": {
       "text/plain": [
-       "(tensor([208759,  18002]),\n",
-       " tensor([34981, 72702]),\n",
+       "(tensor([260983, 284569]),\n",
+       " tensor([41159, 30314]),\n",
        " tensor([[51862, 14281],\n",
-       "         [42118, 49772]]),\n",
-       " tensor([[    0,     0,     0,     0, 26395],\n",
-       "         [    0,     0,     0,     0,     0]]))"
+       "         [42119, 49773]]),\n",
+       " tensor([[0, 0, 0, 0, 0],\n",
+       "         [0, 0, 0, 0, 0]]))"
       ]
      },
      "execution_count": 8,

--- a/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset.py
+++ b/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset.py
@@ -23,8 +23,8 @@ class SpecialIndex(IntEnum):
 def fetch_dataset(
     category: str = "Video_Games",
     dataset_type: Literal[
-        "0core_last_out_w_his", "0core_timestamp_w_his", "raw_review"
-    ] = "0core_last_out_w_his",
+        "0core_timestamp_w_his", "0core_last_out_w_his", "raw_review"
+    ] = "0core_timestamp_w_his",
 ) -> D.DatasetDict:
     """Fetch Amazon Reviews 2023 dataset from the datasets library.
 
@@ -68,7 +68,7 @@ def fetch_metadata(category: str = "Video_Games") -> D.Dataset:
     return metadata
 
 
-def preprocess_dataset(
+def seq_rec_preprocess_dataset(
     dataset_dict: D.DatasetDict, metadata: D.Dataset, filter_no_history: bool = True
 ) -> tuple[
     pl.DataFrame,
@@ -304,9 +304,9 @@ def preprocess_dataset(
     )
 
 
-class AmazonReviewsDatasetItem(NamedTuple):
+class AmazonReviewsSeqRecItem(NamedTuple):
     """
-    Amazon Reviews dataset item
+    Amazon Reviews dataset item for Sequential Recommendation
 
     Fields:
         user_index: user index, shape: (B,)
@@ -327,7 +327,7 @@ class AmazonReviewsDatasetItem(NamedTuple):
     neg_category_indexes: torch.Tensor
 
 
-class AmazonReviewsDataset(Dataset[AmazonReviewsDatasetItem]):
+class AmazonReviewsSeqRecDataset(Dataset[AmazonReviewsSeqRecItem]):
     def __init__(
         self,
         df: pl.DataFrame,
@@ -336,7 +336,7 @@ class AmazonReviewsDataset(Dataset[AmazonReviewsDatasetItem]):
         max_seq_len: int,
         seed: int = 1026,
     ):
-        """Amazon Reviews dataset
+        """Amazon Reviews dataset for sequential recommendation
 
         Args:
             df: dataframe, schema: ["user_index", "history_index", "item_index"]
@@ -391,20 +391,14 @@ class AmazonReviewsDataset(Dataset[AmazonReviewsDatasetItem]):
         else:
             return F.pad(seq, (max_seq_len - len(seq), 0))
 
-    def __getitem__(self, idx: int) -> AmazonReviewsDatasetItem:
+    def __getitem__(self, idx: int) -> AmazonReviewsSeqRecItem:
         """Get item
 
         Args:
             idx: index
 
         Returns:
-            user_index: user index, shape: ()
-            item_history: item history, shape: (self.max_seq_len,)
-            category_history: category history, shape: (self.max_seq_len,)
-            pos_item_index: positive item index, shape: ()
-            pos_category_index: positive category index, shape: ()
-            neg_item_indexes: negative item indexes, shape: (neg_sample_size,)
-            neg_category_indexes: negative category indexes, shape: (neg_sample_size,)
+            AmazonReviewsDatasetItem
         """
         row = self.df.row(idx, named=True)
         user_index = torch.tensor(row["user_index"], dtype=torch.long)
@@ -412,8 +406,10 @@ class AmazonReviewsDataset(Dataset[AmazonReviewsDatasetItem]):
         category_history = torch.tensor(row["history_category_index"], dtype=torch.long)
         # truncate or pad
         # TODO: this operation is implemented in the preprocess_dataset function
-        item_history = AmazonReviewsDataset.trunc_and_pad(item_history, self.max_seq_len)
-        category_history = AmazonReviewsDataset.trunc_and_pad(category_history, self.max_seq_len)
+        item_history = AmazonReviewsSeqRecDataset.trunc_and_pad(item_history, self.max_seq_len)
+        category_history = AmazonReviewsSeqRecDataset.trunc_and_pad(
+            category_history, self.max_seq_len
+        )
         # shape: ()
         pos_item_index = torch.tensor(row["item_index"], dtype=torch.long)
         pos_category_index = torch.tensor(row["category_index"], dtype=torch.long)
@@ -422,7 +418,7 @@ class AmazonReviewsDataset(Dataset[AmazonReviewsDatasetItem]):
             int(pos_item_index.item()), neg_sample_size=self.neg_sample_size
         )
 
-        return AmazonReviewsDatasetItem(
+        return AmazonReviewsSeqRecItem(
             user_index=user_index,
             item_history=item_history,
             category_history=category_history,
@@ -433,7 +429,7 @@ class AmazonReviewsDataset(Dataset[AmazonReviewsDatasetItem]):
         )
 
 
-class AmazonReviewsDataModule(L.LightningDataModule):
+class AmazonReviewsSeqRecDataModule(L.LightningDataModule):
     def __init__(
         self,
         save_dir: pathlib.Path,
@@ -445,7 +441,7 @@ class AmazonReviewsDataModule(L.LightningDataModule):
         eval_negative_sample_size: int = 100,
         filter_no_history: bool = True,
     ):
-        """Amazon Reviews Data Module
+        """Amazon Reviews Data Module for Sequential Recommendation
 
         Args:
             save_dir: save directory for preprocessed dataset
@@ -512,7 +508,9 @@ class AmazonReviewsDataModule(L.LightningDataModule):
                 self.item2index,
                 self.category2index,
                 self.item_index_2_category_index,
-            ) = preprocess_dataset(dataset_dict, metadata, filter_no_history=self.filter_no_history)
+            ) = seq_rec_preprocess_dataset(
+                dataset_dict, metadata, filter_no_history=self.filter_no_history
+            )
 
             # save
             self.train_df.write_parquet(train_path)
@@ -542,14 +540,14 @@ class AmazonReviewsDataModule(L.LightningDataModule):
 
     def setup(self, stage: str) -> None:
         if stage == "fit":
-            self.train_dataset = AmazonReviewsDataset(
+            self.train_dataset = AmazonReviewsSeqRecDataset(
                 self.train_df,
                 random_neg_sampling_pool=self.random_neg_sampling_pool,
                 neg_sample_size=self.neg_sample_size,
                 max_seq_len=self.max_seq_len,
             )
             # NOTE: For ranking metrics, we need to sample more negative items.
-            self.val_dataset = AmazonReviewsDataset(
+            self.val_dataset = AmazonReviewsSeqRecDataset(
                 self.val_df,
                 random_neg_sampling_pool=self.random_neg_sampling_pool,
                 neg_sample_size=self.eval_negative_sample_size,
@@ -557,7 +555,7 @@ class AmazonReviewsDataModule(L.LightningDataModule):
             )
         elif stage == "test":
             # NOTE: For ranking metrics, we need to sample more negative items.
-            self.test_dataset = AmazonReviewsDataset(
+            self.test_dataset = AmazonReviewsSeqRecDataset(
                 self.test_df,
                 random_neg_sampling_pool=self.random_neg_sampling_pool,
                 neg_sample_size=self.eval_negative_sample_size,
@@ -566,7 +564,7 @@ class AmazonReviewsDataModule(L.LightningDataModule):
         else:
             raise NotImplementedError(f"Invalid stage: {stage}")
 
-    def train_dataloader(self) -> DataLoader[AmazonReviewsDatasetItem]:
+    def train_dataloader(self) -> DataLoader[AmazonReviewsSeqRecItem]:
         return DataLoader(
             self.train_dataset,
             batch_size=self.batch_size,
@@ -575,7 +573,7 @@ class AmazonReviewsDataModule(L.LightningDataModule):
             persistent_workers=True,
         )
 
-    def val_dataloader(self) -> DataLoader[AmazonReviewsDatasetItem]:
+    def val_dataloader(self) -> DataLoader[AmazonReviewsSeqRecItem]:
         # NOTE: For ranking metrics, we have more negative samples. So, to avoid OOM, we need to reduce the batch size.
         return DataLoader(
             self.val_dataset,
@@ -584,7 +582,7 @@ class AmazonReviewsDataModule(L.LightningDataModule):
             persistent_workers=True,
         )
 
-    def test_dataloader(self) -> DataLoader[AmazonReviewsDatasetItem]:
+    def test_dataloader(self) -> DataLoader[AmazonReviewsSeqRecItem]:
         # NOTE: For ranking metrics, we have more negative samples. So, to avoid OOM, we need to reduce the batch size.
         return DataLoader(
             self.test_dataset,

--- a/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset.py
+++ b/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset.py
@@ -405,7 +405,7 @@ class AmazonReviewsSeqRecDataset(Dataset[AmazonReviewsSeqRecItem]):
         item_history = torch.tensor(row["history_index"], dtype=torch.long)
         category_history = torch.tensor(row["history_category_index"], dtype=torch.long)
         # truncate or pad
-        # TODO: this operation is implemented in the preprocess_dataset function
+        # TODO: this operation should be implemented in the seq_rec_preprocess_dataset function
         item_history = AmazonReviewsSeqRecDataset.trunc_and_pad(item_history, self.max_seq_len)
         category_history = AmazonReviewsSeqRecDataset.trunc_and_pad(
             category_history, self.max_seq_len


### PR DESCRIPTION
This pull request introduces changes to adapt the Amazon Reviews dataset and its associated data module for sequential recommendation tasks. The modifications include renaming classes and methods to reflect the sequential recommendation context, updating the dataset preprocessing pipeline, and making adjustments to the data loading process. Additionally, the notebook file has been updated to align with these changes.

### Updates for Sequential Recommendation:

* Renamed `AmazonReviewsDatasetItem` to `AmazonReviewsSeqRecItem` and `AmazonReviewsDataset` to `AmazonReviewsSeqRecDataset` to reflect their focus on sequential recommendation tasks. [[1]](diffhunk://#diff-4cc896c4555968527ce4e05a9a7208af2b8e60e92eb0b54d76d0e64c511a358dL307-R309) [[2]](diffhunk://#diff-4cc896c4555968527ce4e05a9a7208af2b8e60e92eb0b54d76d0e64c511a358dL330-R330)
* Updated the `__getitem__` method in `AmazonReviewsSeqRecDataset` to use the renamed class and adjusted the truncation and padding logic accordingly. [[1]](diffhunk://#diff-4cc896c4555968527ce4e05a9a7208af2b8e60e92eb0b54d76d0e64c511a358dL394-R412) [[2]](diffhunk://#diff-4cc896c4555968527ce4e05a9a7208af2b8e60e92eb0b54d76d0e64c511a358dL425-R421)
* Renamed `AmazonReviewsDataModule` to `AmazonReviewsSeqRecDataModule` and updated its methods (`prepare_data`, `setup`, and data loaders) to use sequential recommendation-specific preprocessing and dataset classes. [[1]](diffhunk://#diff-4cc896c4555968527ce4e05a9a7208af2b8e60e92eb0b54d76d0e64c511a358dL436-R432) [[2]](diffhunk://#diff-4cc896c4555968527ce4e05a9a7208af2b8e60e92eb0b54d76d0e64c511a358dL515-R513) [[3]](diffhunk://#diff-4cc896c4555968527ce4e05a9a7208af2b8e60e92eb0b54d76d0e64c511a358dL545-R558) [[4]](diffhunk://#diff-4cc896c4555968527ce4e05a9a7208af2b8e60e92eb0b54d76d0e64c511a358dL569-R567)

### Notebook Updates:

* Renamed the notebook file from `amazon_review_2023.ipynb` to `amazon_reviews_2023.ipynb` for consistency.
* Updated imports and class instantiations in the notebook to use `AmazonReviewsSeqRecDataModule` instead of `AmazonReviewsDataModule`. [[1]](diffhunk://#diff-8408d8795b54043cde38afc5e45a78f28828bd12e957d1dc4257e56c153f0bbeL29-R29) [[2]](diffhunk://#diff-8408d8795b54043cde38afc5e45a78f28828bd12e957d1dc4257e56c153f0bbeL217-R222)
* Adjusted tensor values in the notebook to align with the new sequential recommendation data pipeline.

### Preprocessing Pipeline:

* Renamed the `preprocess_dataset` function to `seq_rec_preprocess_dataset` to indicate its focus on sequential recommendation preprocessing. [[1]](diffhunk://#diff-4cc896c4555968527ce4e05a9a7208af2b8e60e92eb0b54d76d0e64c511a358dL71-R71) [[2]](diffhunk://#diff-4cc896c4555968527ce4e05a9a7208af2b8e60e92eb0b54d76d0e64c511a358dL515-R513)

### Default Dataset Type:

* Changed the default `dataset_type` in `fetch_dataset` to `"0core_timestamp_w_his"` to prioritize timestamp-based sequential data.