### PR TITLE
feat: enhance dataset preprocessing with build_feature_indices and bipartite graph support

### DIFF
--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset.py
@@ -96,31 +96,191 @@ def unk_filter_by_count(df: pl.DataFrame, id_column_name: str, threshold: float)
     return filtered_df
 
 
-def seq_rec_preprocess_dataset(
-    dataset_dict: D.DatasetDict, metadata: D.Dataset, filter_no_history: bool = True
+def build_feature_indices(
+    train_df: pl.DataFrame,
+    meta_df: pl.DataFrame,
+    threshold: float = 0.95,
 ) -> tuple[
-    pl.DataFrame,
-    pl.DataFrame,
-    pl.DataFrame,
-    dict[str, int],
-    dict[str, int],
-    dict[str, int],
-    dict[int, int],
+    dict[str, int],  # user2index
+    dict[str, int],  # item2index
+    dict[str, int],  # category2index
+    dict[int, int],  # item_index_2_category_index
 ]:
-    """preprocess the dataset
+    """Builds indices for users, items, and categories from the provided datasets.
 
     Args:
-        dataset: dataset from the datasets library(transformers)
+        train_df: The Polars DataFrame for training data after initial processing (conversion, metadata join, optional history filtering).
+        meta_df: The Polars DataFrame containing metadata for items, including categories.
+        threshold: The threshold for `unk_filter_by_count` to determine frequent users/items/categories. Defaults to 0.95.
+
+    Returns:
+        A tuple containing:
+            - user2index: Mapping from user ID string to integer index.
+            - item2index: Mapping from item ID (parent_asin) string to integer index.
+            - category2index: Mapping from category string to integer index.
+            - item_index_2_category_index: Mapping from item integer index to category integer index.
+            - processed_train_df: The Polars DataFrame for training data after initial processing (conversion, metadata join, optional history filtering) from which indices were derived.
+    """
+    # Assign unique ID to users, items and categories
+    # 以下の条件を満たすUser/Item/CategoryはUNKに対応させるため、欠損させる。欠損したitemは後ほどUNKに対応させる
+    # - 出現回数が一定以下
+
+    # User index
+    filtered_users_df = unk_filter_by_count(train_df, id_column_name="user_id", threshold=threshold)
+    train_users = (
+        train_df.select(pl.col("user_id"))
+        .unique()
+        .join(filtered_users_df, on="user_id", how="inner", validate="1:1")
+    )
+    user2index: dict[str, int] = {
+        user_id_str: idx
+        for idx, user_id_str in enumerate(
+            train_users["user_id"].sort(),
+            start=len(SpecialIndex),  # 0 is for padding, 1 is for unknown
+        )
+    }
+    user2index.update({"#UNK": SpecialIndex.UNK})
+    assert user2index.get("", -1) == -1, "Empty user should not be in the user2index"
+
+    # Item index
+    train_item_df = (
+        pl.concat(
+            [
+                train_df["parent_asin"],
+                train_df["history"].str.split(" ").explode(),
+            ],
+            how="vertical",
+        )
+        .rename("parent_asin")
+        .to_frame()
+        .filter(pl.col("parent_asin") != "")
+    )
+    filtered_items_df = unk_filter_by_count(
+        train_item_df, id_column_name="parent_asin", threshold=threshold
+    )
+    train_items = (
+        train_item_df.select(pl.col("parent_asin"))
+        .unique()
+        .join(filtered_items_df, on="parent_asin", how="inner", validate="1:1")
+    )
+    item2index: dict[str, int] = {
+        item_asin: idx
+        for idx, item_asin in enumerate(
+            train_items["parent_asin"].sort(),
+            start=len(SpecialIndex),  # 0 is for padding, 1 is for unknown
+        )
+    }
+    item2index.update({"#UNK": SpecialIndex.UNK, "#PAD": SpecialIndex.PAD})
+    assert item2index.get("", -1) == -1, "Empty item should not be in the item2index"
+
+    # Category index
+    # Ensure 'category' column is not null for counting, replace nulls with a placeholder if necessary before counting
+    # or rely on unk_filter_by_count to handle it if it groups nulls.
+    # For safety, let's consider how unk_filter_by_count handles nulls or filter them.
+    # The original code directly uses train_df which has categories joined, potentially with nulls.
+    # unk_filter_by_count groups by id_column_name, nulls would form their own group.
+    # Let's assume train_df already has 'category' column from the join.
+    train_df_for_category_count = train_df.filter(pl.col("category").is_not_null())
+    if train_df_for_category_count.is_empty() and not train_df.is_empty():
+        logger.warning(
+            "No non-null categories found in train_df for category indexing. Category index will be minimal."
+        )
+        # Create a minimal category2index if no categories are found to prevent errors downstream
+        category2index: dict[str, int] = {"#UNK": SpecialIndex.UNK, "#PAD": SpecialIndex.PAD}
+        train_categories = pl.DataFrame({"category": []})  # Empty DataFrame
+    elif train_df_for_category_count.is_empty() and train_df.is_empty():
+        logger.warning("train_df is empty. Category index will be minimal.")
+        category2index = {"#UNK": SpecialIndex.UNK, "#PAD": SpecialIndex.PAD}
+        train_categories = pl.DataFrame({"category": []})  # Empty DataFrame
+    else:
+        filtered_categories_df = unk_filter_by_count(
+            train_df_for_category_count, id_column_name="category", threshold=threshold
+        )
+        train_categories = (
+            train_df_for_category_count.select(pl.col("category"))
+            .unique()
+            .join(filtered_categories_df, on="category", how="inner", validate="1:1")
+        )
+        category2index = {
+            cat_name: idx
+            for idx, cat_name in enumerate(
+                train_categories["category"].sort(),
+                start=len(SpecialIndex),  # 0 is for padding, 1 is for unknown
+            )
+        }
+        category2index.update({"#UNK": SpecialIndex.UNK, "#PAD": SpecialIndex.PAD})
+    assert category2index.get("", -1) == -1, "Empty category should not be in the category2index"
+
+    # Item index to category index mapping
+    item2index_df = pl.from_dict(
+        {"parent_asin": list(item2index.keys()), "item_index": list(item2index.values())}
+    )
+    category2index_df = pl.from_dict(
+        {"category": list(category2index.keys()), "category_index": list(category2index.values())}
+    )
+    item_index_2_category_index_df = item2index_df.join(
+        meta_df,
+        on="parent_asin",
+        how="left",
+        validate="1:1",  # Use the full meta_df for category lookup
+    ).join(category2index_df, on="category", how="left", validate="m:1")
+
+    item_index_2_category_index_df = item_index_2_category_index_df.with_columns(
+        pl.when(pl.col("item_index") == SpecialIndex.PAD)
+        .then(SpecialIndex.PAD)
+        .when(pl.col("category_index").is_null())  # If category was null or not in category2index
+        .then(SpecialIndex.UNK)
+        .otherwise(pl.col("category_index"))
+        .alias("category_index")
+    )
+    item_index_2_category_index: dict[int, int] = {
+        row_item_index: row_category_index
+        for row_item_index, row_category_index in item_index_2_category_index_df[
+            ["item_index", "category_index"]
+        ].iter_rows()
+    }
+    # Ensure all item indices (including PAD, UNK) from item2index are in item_index_2_category_index
+    # UNK items might not have a category in meta_df, or their category might be rare.
+    # PAD items should map to PAD category_index.
+    if (
+        SpecialIndex.UNK in item2index.values()
+        and item2index["#UNK"] not in item_index_2_category_index
+    ):
+        item_index_2_category_index[item2index["#UNK"]] = SpecialIndex.UNK
+    if (
+        SpecialIndex.PAD in item2index.values()
+        and item2index["#PAD"] not in item_index_2_category_index
+    ):
+        item_index_2_category_index[item2index["#PAD"]] = SpecialIndex.PAD
+
+    return (
+        user2index,
+        item2index,
+        category2index,
+        item_index_2_category_index,
+    )
+
+
+def _common_preprocess_dataset(
+    dataset_dict: D.DatasetDict, metadata: D.Dataset, filter_no_history: bool = True
+) -> tuple[
+    tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame],
+    pl.DataFrame,
+    tuple[dict[str, int], dict[str, int], dict[str, int], dict[int, int]],
+    tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame],
+]:
+    """Common preprocessing steps for the dataset
+
+    Args:
+        dataset_dict: dataset from the datasets library(transformers)
         metadata: metadata dataset from the datasets library(transformers)
         filter_no_history: whether to filter out the dataset which has no history. Defaults to True.
 
     Returns:
-        train_df: train dataset
-        val_df: validation dataset
-        test_df: test dataset
-        user2index: user to index dictionary
-        item2index: item to index dictionary
-        category2index: category to index dictionary
+        tuple of train_df, val_df, test_df: preprocessed train, validation and test datasets
+        meta_df: metadata dataframe
+        tuple of user2index, item2index, category2index, item_index_2_category_index: dictionaries for user, item and category indices
+        tuple of user2index_df, item2index_df, category2index_df: dataframes for user, item and category indices
     """
     schema_overrides = {
         "user_id": pl.String,
@@ -151,107 +311,72 @@ def seq_rec_preprocess_dataset(
         val_df = val_df.filter(pl.col("history") != "")
         test_df = test_df.filter(pl.col("history") != "")
 
-    # assign unique ID to users, items and categories
-    # 以下の条件を満たすUser/Item/CategoryはUNKに対応させるため、欠損させる。欠損したitemは後ほどUNKに対応させる
-    # - 出現回数が一定以下
-    threshold = 0.95
-    # user
-    filtered_by_count_df = unk_filter_by_count(
-        train_df, id_column_name="user_id", threshold=threshold
-    )
-    # 出現回数が一定以下のuserを除外
-    train_users = (
-        train_df.select(pl.col("user_id"))
-        .unique()
-        .join(filtered_by_count_df, on="user_id", how="inner", validate="1:1")
-    )
-    user2index: dict[str, int] = {
-        user_id: idx
-        for idx, user_id in enumerate(
-            train_users["user_id"].sort(),
-            start=len(SpecialIndex),  # 0 is for padding, 1 is for unknown
-        )
-    }
-    user2index.update({"#UNK": SpecialIndex.UNK})
+    (
+        user2index,
+        item2index,
+        category2index,
+        item_index_2_category_index,
+    ) = build_feature_indices(train_df, meta_df, threshold=0.95)
     user2index_df = pl.from_dict(
         {"user_id": list(user2index.keys()), "user_index": list(user2index.values())}
     )
-    assert user2index.get("", -1) == -1, "Empty user should not be in the user2index"
-    # item
-    train_item_df = (
-        pl.concat(
-            [train_df["parent_asin"], train_df["history"].str.split(" ").explode()],
-            how="vertical",
-        )
-        .rename("parent_asin")
-        .to_frame()
-        .filter(pl.col("parent_asin") != "")
-    )
-    filtered_by_count_df = unk_filter_by_count(
-        train_item_df, id_column_name="parent_asin", threshold=threshold
-    )
-    train_items = (
-        train_item_df.select(pl.col("parent_asin"))
-        .unique()
-        .join(filtered_by_count_df, on="parent_asin", how="inner", validate="1:1")
-    )
-    item2index: dict[str, int] = {
-        user_id: idx
-        for idx, user_id in enumerate(
-            train_items["parent_asin"].sort(),
-            start=len(SpecialIndex),  # 0 is for padding, 1 is for unknown
-        )
-    }
-    item2index.update({"#UNK": SpecialIndex.UNK, "#PAD": SpecialIndex.PAD})
     item2index_df = pl.from_dict(
         {
             "parent_asin": list(item2index.keys()),
             "item_index": list(item2index.values()),
         }
     )
-    assert item2index.get("", -1) == -1, "Empty item should not be in the item2index"
-    # category
-    filtered_by_count_df = unk_filter_by_count(
-        train_df, id_column_name="category", threshold=threshold
-    )
-    train_categorys = (
-        train_df.select(pl.col("category"))
-        .unique()
-        .join(filtered_by_count_df, on="category", how="inner", validate="1:1")
-    )
-    category2index: dict[str, int] = {
-        user_id: idx
-        for idx, user_id in enumerate(
-            train_categorys["category"].sort(),
-            start=len(SpecialIndex),  # 0 is for padding, 1 is for unknown
-        )
-    }
-    category2index.update({"#UNK": SpecialIndex.UNK, "#PAD": SpecialIndex.PAD})
     category2index_df = pl.from_dict(
         {
             "category": list(category2index.keys()),
             "category_index": list(category2index.values()),
         }
     )
-    assert category2index.get("", -1) == -1, "Empty category should not be in the category2index"
-    # item index to category index
-    item_index_2_category_index_df = item2index_df.join(
-        meta_df, on="parent_asin", how="left", validate="1:1"
-    ).join(category2index_df, on="category", how="left", validate="m:1")
-    item_index_2_category_index_df = item_index_2_category_index_df.with_columns(
-        pl.when(pl.col("item_index") == SpecialIndex.PAD)
-        .then(SpecialIndex.PAD)
-        .when(pl.col("category_index").is_null())
-        .then(SpecialIndex.UNK)
-        .otherwise(pl.col("category_index"))
-        .alias("category_index")
+
+    return (
+        (train_df, val_df, test_df),
+        meta_df,
+        (user2index, item2index, category2index, item_index_2_category_index),
+        (user2index_df, item2index_df, category2index_df),
     )
-    item_index_2_category_index = {
-        item_index: category_index
-        for item_index, category_index in item_index_2_category_index_df[
-            ["item_index", "category_index"]
-        ].iter_rows()
-    }
+
+
+def seq_rec_preprocess_dataset(
+    dataset_dict: D.DatasetDict, metadata: D.Dataset, filter_no_history: bool = True
+) -> tuple[
+    pl.DataFrame,
+    pl.DataFrame,
+    pl.DataFrame,
+    dict[str, int],
+    dict[str, int],
+    dict[str, int],
+    dict[int, int],
+]:
+    """preprocess the dataset
+
+    Args:
+        dataset: dataset from the datasets library(transformers)
+        metadata: metadata dataset from the datasets library(transformers)
+        filter_no_history: whether to filter out the dataset which has no history. Defaults to True.
+
+    Returns:
+        train_df: train dataset
+        val_df: validation dataset
+        test_df: test dataset
+        user2index: user to index dictionary
+        item2index: item to index dictionary
+        category2index: category to index dictionary
+    """
+    (
+        (train_df, val_df, test_df),
+        meta_df,
+        (user2index, item2index, category2index, item_index_2_category_index),
+        (user2index_df, item2index_df, category2index_df),
+    ) = _common_preprocess_dataset(
+        dataset_dict=dataset_dict,
+        metadata=metadata,
+        filter_no_history=filter_no_history,
+    )
 
     # preprocess
     def _preprocess(df: pl.DataFrame) -> pl.DataFrame:
@@ -677,3 +802,78 @@ class AmazonReviewsSeqRecDataModule(L.LightningDataModule):
         Item2Index: {len(self.item2index)}
         Category2Index: {len(self.category2index)}
         """
+
+
+def bipartite_graph_preprocess_dataset(
+    dataset_dict: D.DatasetDict, metadata: D.Dataset
+) -> tuple[
+    pl.DataFrame,
+    pl.DataFrame,
+    pl.DataFrame,
+    dict[str, int],
+    dict[str, int],
+    dict[str, int],
+    dict[int, int],
+]:
+    """Preprocess the dataset for bipartite graph
+
+    Args:
+        dataset_dict: dataset from the datasets library(transformers)
+        metadata: metadata dataset from the datasets library(transformers)
+
+    Returns:
+        bipartite_df: bipartite graph dataframe
+        user2index: user to index dictionary
+        item2index: item to index dictionary
+    """
+
+    (
+        (train_df, val_df, test_df),
+        _,
+        (user2index, item2index, category2index, item_index_2_category_index),
+        _,
+    ) = _common_preprocess_dataset(
+        dataset_dict=dataset_dict,
+        metadata=metadata,
+        filter_no_history=False,
+    )
+
+    def _preprocess(df: pl.DataFrame) -> pl.DataFrame:
+        df = df.group_by("user_id", "parent_asin").agg(
+            pl.max("user_index").alias("user_index"),
+            pl.max("item_index").alias("item_index"),
+            pl.max("category").alias("category"),
+            pl.max("category_index").alias("category_index"),
+            pl.max("rating").alias("rating"),
+            pl.min("timestamp").alias("timestamp"),
+            pl.len().alias("num_ratings"),
+        )
+        df = df.select(
+            [
+                "user_id",
+                "user_index",
+                "parent_asin",
+                "item_index",
+                "category",
+                "category_index",
+                "rating",
+                "timestamp",
+                "num_ratings",
+            ]
+        )
+        return df
+
+    logger.info("Preprocessing the dataset for bipartite graph")
+    train_df = _preprocess(train_df)
+    val_df = _preprocess(val_df)
+    test_df = _preprocess(test_df)
+
+    return (
+        train_df,
+        val_df,
+        test_df,
+        user2index,
+        item2index,
+        category2index,
+        item_index_2_category_index,
+    )

--- a/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset.py
+++ b/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset.py
@@ -1,6 +1,13 @@
 import polars as pl
+from pytest_mock import MockerFixture
 
-from ml_sandbox_libs.data.amazon_reviews_dataset import unk_filter_by_count
+from ml_sandbox_libs.data.amazon_reviews_dataset import (
+    SpecialIndex,
+    bipartite_graph_preprocess_dataset,
+    build_feature_indices,
+    seq_rec_preprocess_dataset,
+    unk_filter_by_count,
+)
 
 
 def test_unk_filter_by_count() -> None:
@@ -9,3 +16,465 @@ def test_unk_filter_by_count() -> None:
     filtered_df = unk_filter_by_count(df, id_column_name="id", threshold=0.96)
     assert len(filtered_df) == 1
     assert filtered_df["id"].item() == 1
+
+
+def test_build_feature_indices() -> None:
+    """Test the build_feature_indices function."""
+    # Create training DataFrame with categories joined
+    train_data: dict[str, list[object]] = {
+        "user_id": ["user1", "user1", "user2", "user2", "user3"]
+        * 20,  # Create more data for threshold
+        "parent_asin": ["item1", "item2", "item1", "item3", "item2"] * 20,
+        "rating": [5.0, 4.0, 5.0, 3.0, 4.0] * 20,
+        "timestamp": [1000000, 1000001, 1000002, 1000003, 1000004] * 20,
+        "history": ["", "item1", "", "item1 item2", "item1"] * 20,
+        "category": [
+            "Games/Action",
+            "Games/RPG",
+            "Games/Action",
+            "Electronics/Computers",
+            "Games/RPG",
+        ]
+        * 20,
+    }
+    train_df = pl.from_dict(train_data)
+
+    # Create metadata DataFrame
+    metadata_data: dict[str, list[object]] = {
+        "parent_asin": ["item1", "item2", "item3"],
+        "category": ["Games/Action", "Games/RPG", "Electronics/Computers"],
+    }
+    meta_df = pl.from_dict(metadata_data)
+
+    # Call the function with DataFrames directly
+    user2index, item2index, category2index, item_index_2_category_index = build_feature_indices(
+        train_df, meta_df, threshold=0.8
+    )
+
+    # Verify results
+    # Check that special indices are included
+    assert "#UNK" in user2index
+    assert "#UNK" in item2index
+    assert "#UNK" in category2index
+    assert "#PAD" in item2index
+    assert "#PAD" in category2index
+
+    # Check that user2index values start from len(SpecialIndex)
+    regular_user_indices = [idx for user, idx in user2index.items() if not user.startswith("#")]
+    assert all(idx >= len(SpecialIndex) for idx in regular_user_indices)
+
+    # Check that item2index values start from len(SpecialIndex)
+    regular_item_indices = [idx for item, idx in item2index.items() if not item.startswith("#")]
+    assert all(idx >= len(SpecialIndex) for idx in regular_item_indices)
+
+    # Check that category2index values start from len(SpecialIndex)
+    regular_category_indices = [
+        idx for cat, idx in category2index.items() if not cat.startswith("#")
+    ]
+    assert all(idx >= len(SpecialIndex) for idx in regular_category_indices)
+
+    # Check that item_index_2_category_index contains mappings for all items
+    assert len(item_index_2_category_index) == len(item2index)
+
+    # Check that special indices map correctly
+    assert item_index_2_category_index[item2index["#UNK"]] == SpecialIndex.UNK
+    assert item_index_2_category_index[item2index["#PAD"]] == SpecialIndex.PAD
+
+
+def test_seq_rec_preprocess_dataset(mocker: MockerFixture) -> None:
+    """Test the seq_rec_preprocess_dataset function."""
+    # Create mock dataset_dict and metadata
+    mock_dataset_dict = mocker.Mock()
+    mock_metadata = mocker.Mock()
+
+    # Mock the return values for _common_preprocess_dataset
+    mock_train_df = pl.DataFrame(
+        {
+            "user_id": ["user1", "user2", "user3"],
+            "parent_asin": ["item1", "item2", "item3"],
+            "rating": [5.0, 4.0, 3.0],
+            "timestamp": [1000000, 1000001, 1000002],
+            "history": ["item0", "item1 item0", "item1 item2"],
+            "category": ["Games/Action", "Games/RPG", "Electronics/Computers"],
+        }
+    )
+
+    mock_val_df = pl.DataFrame(
+        {
+            "user_id": ["user1", "user2", "user3"],
+            "parent_asin": ["item1", "item2", "item3"],
+            "rating": [4.0, 5.0, 3.0],
+            "timestamp": [2000000, 2000001, 2000002],
+            "history": ["item0 item1", "item2", "item1 item0"],
+            "category": ["Games/Action", "Games/RPG", "Electronics/Computers"],
+        }
+    )
+
+    mock_test_df = pl.DataFrame(
+        {
+            "user_id": ["user1", "user2", "user3"],
+            "parent_asin": ["item2", "item3", "item1"],
+            "rating": [5.0, 4.0, 4.5],
+            "timestamp": [3000000, 3000001, 3000002],
+            "history": ["item0 item1 item2", "item1", "item0"],
+            "category": ["Games/RPG", "Electronics/Computers", "Games/Action"],
+        }
+    )
+
+    mock_meta_df = pl.DataFrame(
+        {
+            "parent_asin": ["item0", "item1", "item2", "item3"],
+            "category": ["Games/Action", "Games/Action", "Games/RPG", "Electronics/Computers"],
+        }
+    )
+
+    mock_user2index = {"user1": 2, "user2": 3, "user3": 4, "#UNK": SpecialIndex.UNK}
+    mock_item2index = {
+        "item0": 2,
+        "item1": 3,
+        "item2": 4,
+        "item3": 5,
+        "#UNK": SpecialIndex.UNK,
+        "#PAD": SpecialIndex.PAD,
+    }
+    mock_category2index = {
+        "Games/Action": 2,
+        "Games/RPG": 3,
+        "Electronics/Computers": 4,
+        "#UNK": SpecialIndex.UNK,
+        "#PAD": SpecialIndex.PAD,
+    }
+    mock_item_index_2_category_index = {
+        2: 2,  # item0 -> Games/Action
+        3: 2,  # item1 -> Games/Action
+        4: 3,  # item2 -> Games/RPG
+        5: 4,  # item3 -> Electronics/Computers
+        SpecialIndex.UNK: SpecialIndex.UNK,
+        SpecialIndex.PAD: SpecialIndex.PAD,
+    }
+
+    # Create index DataFrames
+    mock_user2index_df = pl.DataFrame(
+        {"user_id": list(mock_user2index.keys()), "user_index": list(mock_user2index.values())}
+    )
+    mock_item2index_df = pl.DataFrame(
+        {"parent_asin": list(mock_item2index.keys()), "item_index": list(mock_item2index.values())}
+    )
+    mock_category2index_df = pl.DataFrame(
+        {
+            "category": list(mock_category2index.keys()),
+            "category_index": list(mock_category2index.values()),
+        }
+    )
+
+    # Mock _common_preprocess_dataset
+    mock_common_preprocess_return = (
+        (mock_train_df, mock_val_df, mock_test_df),
+        mock_meta_df,
+        (mock_user2index, mock_item2index, mock_category2index, mock_item_index_2_category_index),
+        (mock_user2index_df, mock_item2index_df, mock_category2index_df),
+    )
+
+    mock_common_preprocess_func = mocker.patch(
+        "ml_sandbox_libs.data.amazon_reviews_dataset._common_preprocess_dataset",
+        return_value=mock_common_preprocess_return,
+    )
+
+    # Test with filter_no_history=True (default)
+    result = seq_rec_preprocess_dataset(mock_dataset_dict, mock_metadata, filter_no_history=True)
+
+    (
+        train_df,
+        val_df,
+        test_df,
+        user2index,
+        item2index,
+        category2index,
+        item_index_2_category_index,
+    ) = result
+
+    # Verify return types
+    assert isinstance(train_df, pl.DataFrame)
+    assert isinstance(val_df, pl.DataFrame)
+    assert isinstance(test_df, pl.DataFrame)
+    assert isinstance(user2index, dict)
+    assert isinstance(item2index, dict)
+    assert isinstance(category2index, dict)
+    assert isinstance(item_index_2_category_index, dict)
+
+    # Verify that indices are returned correctly
+    assert user2index == mock_user2index
+    assert item2index == mock_item2index
+    assert category2index == mock_category2index
+    assert item_index_2_category_index == mock_item_index_2_category_index
+
+    # Verify expected columns in output DataFrames
+    expected_columns = [
+        "user_id",
+        "user_index",
+        "parent_asin",
+        "item_index",
+        "category",
+        "category_index",
+        "rating",
+        "timestamp",
+        "history",
+        "history_index",
+        "history_category",
+        "history_category_index",
+    ]
+
+    assert train_df.columns == expected_columns
+    assert val_df.columns == expected_columns
+    assert test_df.columns == expected_columns
+
+    # Verify that empty history rows are filtered out when filter_no_history=True
+    # In our mock data, some rows have empty history ("")
+    assert all(len(history) > 0 for history in train_df["history"])
+
+    # Verify that user_index, item_index, category_index are not null and are integers
+    assert train_df["user_index"].dtype == pl.Int64
+    assert train_df["item_index"].dtype == pl.Int64
+    assert train_df["category_index"].dtype == pl.Int64
+
+    # Verify that history_index and history_category_index are lists
+    assert train_df["history_index"].dtype == pl.List(pl.Int64)
+    assert train_df["history_category_index"].dtype == pl.List(pl.Int64)
+
+    # Verify that _common_preprocess_dataset was called with correct parameters
+    # The function should be called once with the dataset_dict and metadata
+    # We can't easily verify the exact call parameters since they're complex objects
+    mock_common_preprocess_func.assert_called_once_with(
+        dataset_dict=mock_dataset_dict, metadata=mock_metadata, filter_no_history=True
+    )
+
+
+def test_bipartite_graph_preprocess_dataset(mocker: MockerFixture) -> None:
+    """Test the bipartite_graph_preprocess_dataset function."""
+    # Create mock dataset_dict and metadata
+    mock_dataset_dict = mocker.Mock()
+    mock_metadata = mocker.Mock()
+
+    # Mock the return values for _common_preprocess_dataset
+    # Create data with duplicate user_id and parent_asin combinations to test groupby and aggregation
+    mock_train_df = pl.DataFrame(
+        {
+            "user_id": ["user1", "user1", "user2", "user2", "user2", "user3"],
+            "user_index": [2, 2, 3, 3, 3, 4],
+            "parent_asin": ["item1", "item1", "item2", "item2", "item3", "item1"],
+            "item_index": [2, 2, 3, 3, 4, 2],
+            "rating": [5.0, 4.0, 3.0, 4.0, 5.0, 2.0],
+            "timestamp": [1000000, 1000010, 1000001, 1000005, 1000002, 1000003],
+            "history": ["", "item0", "item1", "item1 item0", "item2", ""],
+            "category": [
+                "Games/Action",
+                "Games/Action",
+                "Games/RPG",
+                "Games/RPG",
+                "Electronics/Computers",
+                "Games/Action",
+            ],
+            "category_index": [2, 2, 3, 3, 4, 2],
+        }
+    )
+
+    mock_val_df = pl.DataFrame(
+        {
+            "user_id": ["user1", "user2", "user3"],
+            "user_index": [2, 3, 4],
+            "parent_asin": ["item2", "item1", "item3"],
+            "item_index": [3, 2, 4],
+            "rating": [4.0, 5.0, 3.0],
+            "timestamp": [2000000, 2000001, 2000002],
+            "history": ["item0 item1", "item2", "item1 item0"],
+            "category": ["Games/RPG", "Games/Action", "Electronics/Computers"],
+            "category_index": [3, 2, 4],
+        }
+    )
+
+    mock_test_df = pl.DataFrame(
+        {
+            "user_id": ["user1", "user2", "user3"],
+            "user_index": [2, 3, 4],
+            "parent_asin": ["item3", "item3", "item2"],
+            "item_index": [4, 4, 3],
+            "rating": [5.0, 4.0, 4.5],
+            "timestamp": [3000000, 3000001, 3000002],
+            "history": ["item0 item1 item2", "item1", "item0"],
+            "category": ["Electronics/Computers", "Electronics/Computers", "Games/RPG"],
+            "category_index": [4, 4, 3],
+        }
+    )
+
+    mock_meta_df = pl.DataFrame(
+        {
+            "parent_asin": ["item1", "item2", "item3"],
+            "category": ["Games/Action", "Games/RPG", "Electronics/Computers"],
+        }
+    )
+
+    mock_user2index = {"user1": 2, "user2": 3, "user3": 4, "#UNK": SpecialIndex.UNK}
+    mock_item2index = {
+        "item1": 2,
+        "item2": 3,
+        "item3": 4,
+        "#UNK": SpecialIndex.UNK,
+        "#PAD": SpecialIndex.PAD,
+    }
+    mock_category2index = {
+        "Games/Action": 2,
+        "Games/RPG": 3,
+        "Electronics/Computers": 4,
+        "#UNK": SpecialIndex.UNK,
+        "#PAD": SpecialIndex.PAD,
+    }
+    mock_item_index_2_category_index = {
+        2: 2,  # item1 -> Games/Action
+        3: 3,  # item2 -> Games/RPG
+        4: 4,  # item3 -> Electronics/Computers
+        SpecialIndex.UNK: SpecialIndex.UNK,
+        SpecialIndex.PAD: SpecialIndex.PAD,
+    }
+
+    # Create index DataFrames
+    mock_user2index_df = pl.DataFrame(
+        {"user_id": list(mock_user2index.keys()), "user_index": list(mock_user2index.values())}
+    )
+    mock_item2index_df = pl.DataFrame(
+        {"parent_asin": list(mock_item2index.keys()), "item_index": list(mock_item2index.values())}
+    )
+    mock_category2index_df = pl.DataFrame(
+        {
+            "category": list(mock_category2index.keys()),
+            "category_index": list(mock_category2index.values()),
+        }
+    )
+
+    # Mock _common_preprocess_dataset
+    mock_common_preprocess_return = (
+        (mock_train_df, mock_val_df, mock_test_df),
+        mock_meta_df,
+        (mock_user2index, mock_item2index, mock_category2index, mock_item_index_2_category_index),
+        (mock_user2index_df, mock_item2index_df, mock_category2index_df),
+    )
+
+    mock_common_preprocess_func = mocker.patch(
+        "ml_sandbox_libs.data.amazon_reviews_dataset._common_preprocess_dataset",
+        return_value=mock_common_preprocess_return,
+    )
+
+    # Call the function
+    result = bipartite_graph_preprocess_dataset(mock_dataset_dict, mock_metadata)
+
+    (
+        train_df,
+        val_df,
+        test_df,
+        user2index,
+        item2index,
+        category2index,
+        item_index_2_category_index,
+    ) = result
+
+    # Verify return types
+    assert isinstance(train_df, pl.DataFrame)
+    assert isinstance(val_df, pl.DataFrame)
+    assert isinstance(test_df, pl.DataFrame)
+    assert isinstance(user2index, dict)
+    assert isinstance(item2index, dict)
+    assert isinstance(category2index, dict)
+    assert isinstance(item_index_2_category_index, dict)
+
+    # Verify that indices are returned correctly
+    assert user2index == mock_user2index
+    assert item2index == mock_item2index
+    assert category2index == mock_category2index
+    assert item_index_2_category_index == mock_item_index_2_category_index
+
+    # Verify expected columns in output DataFrames
+    expected_columns = [
+        "user_id",
+        "user_index",
+        "parent_asin",
+        "item_index",
+        "category",
+        "category_index",
+        "rating",
+        "timestamp",
+        "num_ratings",
+    ]
+
+    assert train_df.columns == expected_columns
+    assert val_df.columns == expected_columns
+    assert test_df.columns == expected_columns
+
+    # Verify aggregation behavior for train_df
+    # Should have grouped by user_id and parent_asin and aggregated values
+    # user1 + item1: 2 interactions -> max rating, min timestamp, count=2
+    user1_item1_rows = train_df.filter(
+        (pl.col("user_id") == "user1") & (pl.col("parent_asin") == "item1")
+    )
+    assert len(user1_item1_rows) == 1
+    assert user1_item1_rows["user_index"].item() == 2
+    assert user1_item1_rows["item_index"].item() == 2
+    assert user1_item1_rows["category"].item() == "Games/Action"
+    assert user1_item1_rows["category_index"].item() == 2
+    assert user1_item1_rows["rating"].item() == 5.0  # max of 5.0 and 4.0
+    assert user1_item1_rows["timestamp"].item() == 1000000  # min of 1000000 and 1000010
+    assert user1_item1_rows["num_ratings"].item() == 2
+
+    # user2 + item2: 2 interactions -> max rating, min timestamp, count=2
+    user2_item2_rows = train_df.filter(
+        (pl.col("user_id") == "user2") & (pl.col("parent_asin") == "item2")
+    )
+    assert len(user2_item2_rows) == 1
+    assert user2_item2_rows["user_index"].item() == 3
+    assert user2_item2_rows["item_index"].item() == 3
+    assert user2_item2_rows["category"].item() == "Games/RPG"
+    assert user2_item2_rows["category_index"].item() == 3
+    assert user2_item2_rows["rating"].item() == 4.0  # max of 3.0 and 4.0
+    assert user2_item2_rows["timestamp"].item() == 1000001  # min of 1000001 and 1000005
+    assert user2_item2_rows["num_ratings"].item() == 2
+
+    # user2 + item3: 1 interaction -> original values, count=1
+    user2_item3_rows = train_df.filter(
+        (pl.col("user_id") == "user2") & (pl.col("parent_asin") == "item3")
+    )
+    assert len(user2_item3_rows) == 1
+    assert user2_item3_rows["user_index"].item() == 3
+    assert user2_item3_rows["item_index"].item() == 4
+    assert user2_item3_rows["category"].item() == "Electronics/Computers"
+    assert user2_item3_rows["category_index"].item() == 4
+    assert user2_item3_rows["rating"].item() == 5.0
+    assert user2_item3_rows["timestamp"].item() == 1000002
+    assert user2_item3_rows["num_ratings"].item() == 1
+
+    # user3 + item1: 1 interaction -> original values, count=1
+    user3_item1_rows = train_df.filter(
+        (pl.col("user_id") == "user3") & (pl.col("parent_asin") == "item1")
+    )
+    assert len(user3_item1_rows) == 1
+    assert user3_item1_rows["user_index"].item() == 4
+    assert user3_item1_rows["item_index"].item() == 2
+    assert user3_item1_rows["category"].item() == "Games/Action"
+    assert user3_item1_rows["category_index"].item() == 2
+    assert user3_item1_rows["rating"].item() == 2.0
+    assert user3_item1_rows["timestamp"].item() == 1000003
+    assert user3_item1_rows["num_ratings"].item() == 1
+
+    # Verify that val_df and test_df have same structure but no aggregation (each user-item pair is unique)
+    assert len(val_df) == 3
+    assert len(test_df) == 3
+    assert all(val_df["num_ratings"] == 1)
+    assert all(test_df["num_ratings"] == 1)
+
+    # Verify that index columns are present and have correct data types
+    assert train_df["user_index"].dtype == pl.Int64
+    assert train_df["item_index"].dtype == pl.Int64
+    assert train_df["category_index"].dtype == pl.Int64
+
+    # Verify that _common_preprocess_dataset was called with correct parameters
+    # Should be called with filter_no_history=False
+    mock_common_preprocess_func.assert_called_once_with(
+        dataset_dict=mock_dataset_dict, metadata=mock_metadata, filter_no_history=False
+    )


### PR DESCRIPTION
This pull request refactors and enhances preprocessing functions for the Amazon Reviews dataset, introducing modularity and new functionality. Key changes include splitting preprocessing logic into reusable components, adding a new preprocessing function for bipartite graph construction, and improving the handling of edge cases like missing categories. These updates aim to make the codebase more maintainable and extendable.

### Refactoring and Modularity Improvements:
* Introduced `_common_preprocess_dataset` to encapsulate shared preprocessing logic, such as schema overrides, metadata joining, and history filtering. This modular function is reused across other preprocessing functions.
* Refactored `seq_rec_preprocess_dataset` to delegate common preprocessing steps to `_common_preprocess_dataset`, improving code reuse and clarity.

### New Functionality:
* Added `build_feature_indices`, a dedicated function for generating user, item, and category indices, along with mappings between item indices and category indices. This separates index-building logic from dataset preprocessing for better maintainability.
* Created `bipartite_graph_preprocess_dataset`, a new function for preparing the dataset specifically for bipartite graph analysis. It aggregates user-item interactions and computes additional features like the number of ratings.

### Robustness Enhancements:
* Improved handling of missing or null categories during category indexing, including logging warnings and creating minimal indices when necessary. This ensures the preprocessing pipeline is resilient to edge cases.