### PR TITLE
ci: fix concurrency group to prevent cross-branch job cancellation

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -51,7 +51,7 @@ jobs:
     env:
       RUFF_OUTPUT_FORMAT: github
     concurrency:
-      group: ${{ github.workflow }}-${{ matrix.project }}
+      group: ${{ github.workflow }}-${{ matrix.project }}-${{ github.ref }}
       cancel-in-progress: true
     defaults:
       run:


### PR DESCRIPTION
## Changes
- Updated the job-level `concurrency.group` in `python-ci.yml` to include `github.ref`.
- This ensures that jobs triggered from different branches for the same project are not canceled by one another, while still allowing `cancel-in-progress` to work for multiple commits on the same branch.