### PR TITLE
ci: improve concurrency and implement dynamic Renovate grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
   "timezone": "Asia/Tokyo",
-  "schedule": ["on the first and third monday of the month"],
+  "schedule": ["before 8am every 2 weeks on monday"],
   "minimumReleaseAge": "14 days",
   "lockFileMaintenance": {
     "enabled": true,

--- a/renovate.json
+++ b/renovate.json
@@ -60,7 +60,7 @@
     },
     {
       "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
+      "automerge": false
     },
     {
       "matchUpdateTypes": ["major"],

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,26 @@
   },
   "packageRules": [
     {
+      "matchPaths": ["projects/sentiment_analysis/**"],
+      "groupName": "sentiment-analysis dependencies"
+    },
+    {
+      "matchPaths": ["projects/recsys-ranking/**"],
+      "groupName": "recsys-ranking dependencies"
+    },
+    {
+      "matchPaths": ["projects/recsys-candidate-generation/**"],
+      "groupName": "recsys-candidate-generation dependencies"
+    },
+    {
+      "matchPaths": ["libs/ml_sandbox_libs/**"],
+      "groupName": "ml-sandbox-libs dependencies"
+    },
+    {
+      "matchPaths": ["apps/vertex-job-runner/**"],
+      "groupName": "vertex-job-runner dependencies"
+    },
+    {
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "minimumReleaseAge": "14 days"

--- a/renovate.json
+++ b/renovate.json
@@ -10,63 +10,39 @@
   },
   "packageRules": [
     {
-      "matchPaths": ["projects/sentiment_analysis/**"],
+      "matchPaths": ["projects/[^/]+/**"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "sentiment-analysis minor dependencies",
+      "groupName": "{{{parentDir}}} minor dependencies",
       "automerge": false
     },
     {
-      "matchPaths": ["projects/sentiment_analysis/**"],
+      "matchPaths": ["projects/[^/]+/**"],
       "matchUpdateTypes": ["major"],
-      "groupName": "sentiment-analysis major dependencies",
+      "groupName": "{{{parentDir}}} major dependencies",
       "automerge": false
     },
     {
-      "matchPaths": ["projects/recsys-ranking/**"],
+      "matchPaths": ["libs/[^/]+/**"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "recsys-ranking minor dependencies",
+      "groupName": "{{{parentDir}}} minor dependencies",
       "automerge": false
     },
     {
-      "matchPaths": ["projects/recsys-ranking/**"],
+      "matchPaths": ["libs/[^/]+/**"],
       "matchUpdateTypes": ["major"],
-      "groupName": "recsys-ranking major dependencies",
+      "groupName": "{{{parentDir}}} major dependencies",
       "automerge": false
     },
     {
-      "matchPaths": ["projects/recsys-candidate-generation/**"],
+      "matchPaths": ["apps/[^/]+/**"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "recsys-candidate-generation minor dependencies",
+      "groupName": "{{{parentDir}}} minor dependencies",
       "automerge": false
     },
     {
-      "matchPaths": ["projects/recsys-candidate-generation/**"],
+      "matchPaths": ["apps/[^/]+/**"],
       "matchUpdateTypes": ["major"],
-      "groupName": "recsys-candidate-generation major dependencies",
-      "automerge": false
-    },
-    {
-      "matchPaths": ["libs/ml_sandbox_libs/**"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "ml-sandbox-libs minor dependencies",
-      "automerge": false
-    },
-    {
-      "matchPaths": ["libs/ml_sandbox_libs/**"],
-      "matchUpdateTypes": ["major"],
-      "groupName": "ml-sandbox-libs major dependencies",
-      "automerge": false
-    },
-    {
-      "matchPaths": ["apps/vertex-job-runner/**"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "vertex-job-runner minor dependencies",
-      "automerge": false
-    },
-    {
-      "matchPaths": ["apps/vertex-job-runner/**"],
-      "matchUpdateTypes": ["major"],
-      "groupName": "vertex-job-runner major dependencies",
+      "groupName": "{{{parentDir}}} major dependencies",
       "automerge": false
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -7,23 +7,53 @@
   "packageRules": [
     {
       "matchPaths": ["projects/sentiment_analysis/**"],
-      "groupName": "sentiment-analysis dependencies"
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "sentiment-analysis minor dependencies"
+    },
+    {
+      "matchPaths": ["projects/sentiment_analysis/**"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "sentiment-analysis major dependencies"
     },
     {
       "matchPaths": ["projects/recsys-ranking/**"],
-      "groupName": "recsys-ranking dependencies"
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "recsys-ranking minor dependencies"
+    },
+    {
+      "matchPaths": ["projects/recsys-ranking/**"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "recsys-ranking major dependencies"
     },
     {
       "matchPaths": ["projects/recsys-candidate-generation/**"],
-      "groupName": "recsys-candidate-generation dependencies"
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "recsys-candidate-generation minor dependencies"
+    },
+    {
+      "matchPaths": ["projects/recsys-candidate-generation/**"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "recsys-candidate-generation major dependencies"
     },
     {
       "matchPaths": ["libs/ml_sandbox_libs/**"],
-      "groupName": "ml-sandbox-libs dependencies"
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "ml-sandbox-libs minor dependencies"
+    },
+    {
+      "matchPaths": ["libs/ml_sandbox_libs/**"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "ml-sandbox-libs major dependencies"
     },
     {
       "matchPaths": ["apps/vertex-job-runner/**"],
-      "groupName": "vertex-job-runner dependencies"
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "vertex-job-runner minor dependencies"
+    },
+    {
+      "matchPaths": ["apps/vertex-job-runner/**"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "vertex-job-runner major dependencies"
     },
     {
       "matchUpdateTypes": ["minor", "patch"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,46 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
+  "extends": ["config:recommended"],
   "timezone": "Asia/Tokyo",
   "schedule": ["every 2 weeks on monday"],
   "minimumReleaseAge": "14 days",
   "lockFileMaintenance": {
     "enabled": true,
-    "automerge": true
+    "automerge": false
   },
   "packageRules": [
     {
-      "matchPaths": ["projects/[^/]+/**"],
+      "matchPaths": ["projects/*/**", "libs/*/**", "apps/*/**"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "{{{parentDir}}} minor dependencies",
       "automerge": false
     },
     {
-      "matchPaths": ["projects/[^/]+/**"],
-      "matchUpdateTypes": ["major"],
-      "groupName": "{{{parentDir}}} major dependencies",
-      "automerge": false
-    },
-    {
-      "matchPaths": ["libs/[^/]+/**"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "{{{parentDir}}} minor dependencies",
-      "automerge": false
-    },
-    {
-      "matchPaths": ["libs/[^/]+/**"],
-      "matchUpdateTypes": ["major"],
-      "groupName": "{{{parentDir}}} major dependencies",
-      "automerge": false
-    },
-    {
-      "matchPaths": ["apps/[^/]+/**"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "{{{parentDir}}} minor dependencies",
-      "automerge": false
-    },
-    {
-      "matchPaths": ["apps/[^/]+/**"],
+      "matchPaths": ["projects/*/**", "libs/*/**", "apps/*/**"],
       "matchUpdateTypes": ["major"],
       "groupName": "{{{parentDir}}} major dependencies",
       "automerge": false

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:best-practices"],
   "timezone": "Asia/Tokyo",
   "schedule": ["every 2 weeks on monday"],
   "minimumReleaseAge": "14 days",
   "lockFileMaintenance": {
     "enabled": true,
-    "automerge": false
+    "automerge": true
   },
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["on the first and third monday of the month"],
+  "minimumReleaseAge": "14 days",
   "lockFileMaintenance": {
     "enabled": true
   },
@@ -57,8 +60,7 @@
     },
     {
       "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
-      "minimumReleaseAge": "14 days"
+      "automerge": true
     },
     {
       "matchUpdateTypes": ["major"],

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
   "timezone": "Asia/Tokyo",
-  "schedule": ["every 2 weeks on monday"],
+  "schedule": ["on the first and third monday of the month"],
   "minimumReleaseAge": "14 days",
   "lockFileMaintenance": {
     "enabled": true,

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "minimumReleaseAge": "14 days",
   "lockFileMaintenance": {
     "enabled": true,
-    "automerge": true
+    "automerge": false
   },
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -2,68 +2,71 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "timezone": "Asia/Tokyo",
-  "schedule": ["on the first and third monday of the month"],
+  "schedule": ["every 2 weeks on monday"],
   "minimumReleaseAge": "14 days",
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "automerge": false
   },
   "packageRules": [
     {
       "matchPaths": ["projects/sentiment_analysis/**"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "sentiment-analysis minor dependencies"
+      "groupName": "sentiment-analysis minor dependencies",
+      "automerge": false
     },
     {
       "matchPaths": ["projects/sentiment_analysis/**"],
       "matchUpdateTypes": ["major"],
-      "groupName": "sentiment-analysis major dependencies"
-    },
-    {
-      "matchPaths": ["projects/recsys-ranking/**"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "recsys-ranking minor dependencies"
-    },
-    {
-      "matchPaths": ["projects/recsys-ranking/**"],
-      "matchUpdateTypes": ["major"],
-      "groupName": "recsys-ranking major dependencies"
-    },
-    {
-      "matchPaths": ["projects/recsys-candidate-generation/**"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "recsys-candidate-generation minor dependencies"
-    },
-    {
-      "matchPaths": ["projects/recsys-candidate-generation/**"],
-      "matchUpdateTypes": ["major"],
-      "groupName": "recsys-candidate-generation major dependencies"
-    },
-    {
-      "matchPaths": ["libs/ml_sandbox_libs/**"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "ml-sandbox-libs minor dependencies"
-    },
-    {
-      "matchPaths": ["libs/ml_sandbox_libs/**"],
-      "matchUpdateTypes": ["major"],
-      "groupName": "ml-sandbox-libs major dependencies"
-    },
-    {
-      "matchPaths": ["apps/vertex-job-runner/**"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "vertex-job-runner minor dependencies"
-    },
-    {
-      "matchPaths": ["apps/vertex-job-runner/**"],
-      "matchUpdateTypes": ["major"],
-      "groupName": "vertex-job-runner major dependencies"
-    },
-    {
-      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "sentiment-analysis major dependencies",
       "automerge": false
     },
     {
+      "matchPaths": ["projects/recsys-ranking/**"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "recsys-ranking minor dependencies",
+      "automerge": false
+    },
+    {
+      "matchPaths": ["projects/recsys-ranking/**"],
       "matchUpdateTypes": ["major"],
+      "groupName": "recsys-ranking major dependencies",
+      "automerge": false
+    },
+    {
+      "matchPaths": ["projects/recsys-candidate-generation/**"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "recsys-candidate-generation minor dependencies",
+      "automerge": false
+    },
+    {
+      "matchPaths": ["projects/recsys-candidate-generation/**"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "recsys-candidate-generation major dependencies",
+      "automerge": false
+    },
+    {
+      "matchPaths": ["libs/ml_sandbox_libs/**"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "ml-sandbox-libs minor dependencies",
+      "automerge": false
+    },
+    {
+      "matchPaths": ["libs/ml_sandbox_libs/**"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "ml-sandbox-libs major dependencies",
+      "automerge": false
+    },
+    {
+      "matchPaths": ["apps/vertex-job-runner/**"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "vertex-job-runner minor dependencies",
+      "automerge": false
+    },
+    {
+      "matchPaths": ["apps/vertex-job-runner/**"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "vertex-job-runner major dependencies",
       "automerge": false
     }
   ]


### PR DESCRIPTION
## Changes
### CI Improvements (`python-ci.yml`)
- Updated `concurrency.group` to include `github.ref`.
- This allows jobs on different branches to run in parallel even for the same project, preventing cross-branch cancellations.

### Renovate Configuration (`renovate.json`)
- **Dynamic Grouping**: Used `{{{parentDir}}}` template and regex path matching (`projects/[^/]+/**`) to automatically group dependency updates by project directory.
- **Project Separation**: Created separate groups for `minor/patch` and `major` updates for each project.
- **Bi-weekly Schedule**: Set to run `every 2 weeks on monday` to reduce maintenance overhead.
- **Stability**: Configured `minimumReleaseAge: 14 days` to ensure only stable versions are proposed.
- **Manual Review**: Explicitly disabled `automerge` for all rules to ensure human oversight.