### PR TITLE
refactor(data): type Amazon Reviews preprocessing artifacts

### DIFF
--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/__init__.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/__init__.py
@@ -1,10 +1,13 @@
 from .bipartite_graph import (
     AmazonReviewsBipartiteGraphBatch,
     AmazonReviewsBipartiteGraphDataModule,
+    AmazonReviewsBipartiteGraphPreprocessedResult,
     bipartite_graph_preprocess_dataset,
     to_bipartite_graph_batch,
 )
 from .common import (
+    AmazonReviewsIndices,
+    AmazonReviewsPreprocessedResult,
     SpecialCategoryIndex,
     SpecialItemIndex,
     SpecialUserIndex,
@@ -12,20 +15,27 @@ from .common import (
     fetch_metadata,
 )
 from .seq_rec import (
+    AmazonReviewsItemMetadata,
     AmazonReviewsSeqRecBatch,
     AmazonReviewsSeqRecDataModule,
     AmazonReviewsSeqRecDataset,
     AmazonReviewsSeqRecItem,
+    AmazonReviewsSeqRecPreprocessedResult,
     seq_rec_preprocess_dataset,
 )
 
 __all__ = [
     "AmazonReviewsBipartiteGraphBatch",
     "AmazonReviewsBipartiteGraphDataModule",
+    "AmazonReviewsBipartiteGraphPreprocessedResult",
+    "AmazonReviewsIndices",
+    "AmazonReviewsItemMetadata",
+    "AmazonReviewsPreprocessedResult",
     "AmazonReviewsSeqRecBatch",
     "AmazonReviewsSeqRecDataModule",
     "AmazonReviewsSeqRecDataset",
     "AmazonReviewsSeqRecItem",
+    "AmazonReviewsSeqRecPreprocessedResult",
     "SpecialCategoryIndex",
     "SpecialItemIndex",
     "SpecialUserIndex",

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/bipartite_graph.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/bipartite_graph.py
@@ -15,6 +15,7 @@ from torch_geometric.loader import LinkNeighborLoader
 from torch_geometric.sampler import NegativeSampling
 
 from .common import (
+    AmazonReviewsIndices,
     SpecialCategoryIndex,
     SpecialItemIndex,
     SpecialUserIndex,
@@ -24,15 +25,17 @@ from .common import (
 )
 
 
+@dataclass(frozen=True)
+class AmazonReviewsBipartiteGraphPreprocessedResult:
+    """Container for bipartite graph preprocessing artifacts."""
+
+    all_df: pl.DataFrame
+    indices: AmazonReviewsIndices
+
+
 def bipartite_graph_preprocess_dataset(
     dataset_dict: D.DatasetDict, metadata: D.Dataset
-) -> tuple[
-    pl.DataFrame,
-    dict[str, int],
-    dict[str, int],
-    dict[str, int],
-    dict[int, int],
-]:
+) -> AmazonReviewsBipartiteGraphPreprocessedResult:
     """Preprocess Amazon Reviews interactions for bipartite graph construction.
 
     This function merges train, validation, and test interactions into a single
@@ -45,30 +48,24 @@ def bipartite_graph_preprocess_dataset(
         metadata: Product metadata dataset containing item categories.
 
     Returns:
-        A tuple containing the preprocessed interaction dataframe and lookup tables:
-            - ``all_df``: Combined dataframe with columns ``split``, ``user_id``,
-              ``user_index``, ``parent_asin``, ``item_index``, ``category``,
-              ``category_index``, ``rating``, ``timestamp``, and ``num_ratings``.
-            - ``user2index``: Mapping from user IDs to integer indices.
-            - ``item2index``: Mapping from item ASINs to integer indices.
-            - ``category2index``: Mapping from category names to integer indices.
-            - ``item_index_2_category_index``: Mapping from item indices to category
-              indices.
+        AmazonReviewsBipartiteGraphPreprocessedResult: Combined interaction
+            dataframe and lookup indices for graph construction.
 
     Raises:
         ValueError: If the same user-item pair appears more than once after
             aggregation.
     """
 
-    (
-        (train_df, val_df, test_df),
-        _,
-        (user2index, item2index, category2index, item_index_2_category_index),
-        (user2index_df, item2index_df, category2index_df),
-    ) = common_preprocess_dataset(
+    processed = common_preprocess_dataset(
         dataset_dict=dataset_dict,
         metadata=metadata,
         filter_no_history=False,
+    )
+    train_df, val_df, test_df = processed.train_df, processed.val_df, processed.test_df
+    user2index_df, item2index_df, category2index_df = (
+        processed.user2index_df,
+        processed.item2index_df,
+        processed.category2index_df,
     )
 
     def _preprocess(df: pl.DataFrame) -> pl.DataFrame:
@@ -124,12 +121,9 @@ def bipartite_graph_preprocess_dataset(
     )
     all_df = _preprocess(all_df)
 
-    return (
-        all_df,
-        user2index,
-        item2index,
-        category2index,
-        item_index_2_category_index,
+    return AmazonReviewsBipartiteGraphPreprocessedResult(
+        all_df=all_df,
+        indices=processed.indices,
     )
 
 
@@ -414,7 +408,6 @@ class AmazonReviewsBipartiteGraphDataModule(L.LightningDataModule):
         batch_size: int = 32,
         num_workers: int = 2,
         neg_sample_size: int = 1,
-        sampling_val_test: bool = False,
         eval_negative_sample_size: int = 100,
         num_neighbors: Sequence[int] = (10, 5),
     ) -> None:
@@ -422,12 +415,12 @@ class AmazonReviewsBipartiteGraphDataModule(L.LightningDataModule):
 
         Args:
             save_dir: Directory path reserved for preprocessed dataset files.
-            batch_size: Number of samples per batch for data loaders. Defaults to 32.
-            num_workers: Number of worker processes for data loading. Defaults to 2.
-            neg_sample_size: Number of triplet negatives sampled per positive edge
-                during training.
-            sampling_val_test: Unused compatibility argument kept to align with other
-                DataModules in this package.
+            batch_size: Number of samples per batch for data loaders. Defaults
+                to 32.
+            num_workers: Number of worker processes for data loading. Defaults
+                to 2.
+            neg_sample_size: Number of triplet negatives sampled per positive
+                edge during training.
             eval_negative_sample_size: Number of triplet negatives sampled per
                 positive edge during validation and test.
             num_neighbors: Number of neighbors sampled per hop by
@@ -443,7 +436,6 @@ class AmazonReviewsBipartiteGraphDataModule(L.LightningDataModule):
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.neg_sample_size = neg_sample_size
-        self.sampling_val_test = sampling_val_test
         self.eval_negative_sample_size = eval_negative_sample_size
         self.num_neighbors = list(num_neighbors)
         self.transform = T.Compose([T.RemoveSelfLoops()])
@@ -465,18 +457,12 @@ class AmazonReviewsBipartiteGraphDataModule(L.LightningDataModule):
 
         dataset_dict = fetch_dataset()
         metadata = fetch_metadata()
-        (
-            all_df,
-            user2index,
-            item2index,
-            category2index,
-            item_index_2_category_index,
-        ) = bipartite_graph_preprocess_dataset(dataset_dict=dataset_dict, metadata=metadata)
-        self.all_df = all_df
-        self.user2index = user2index
-        self.item2index = item2index
-        self.category2index = category2index
-        self.item_index_2_category_index = item_index_2_category_index
+        processed = bipartite_graph_preprocess_dataset(dataset_dict=dataset_dict, metadata=metadata)
+        self.all_df = processed.all_df
+        self.user2index = processed.indices.user2index
+        self.item2index = processed.indices.item2index
+        self.category2index = processed.indices.category2index
+        self.item_index_2_category_index = processed.indices.item_index_2_category_index
         self._is_prepared = True
 
     def setup(self, stage: str) -> None:

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/common.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/common.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from enum import IntEnum
 from typing import Literal
 
@@ -18,6 +19,30 @@ class SpecialItemIndex(IntEnum):
 class SpecialCategoryIndex(IntEnum):
     PAD = 0  # corresponds to padding id
     UNK = 1  # corresponds to unknown id
+
+
+@dataclass(frozen=True)
+class AmazonReviewsIndices:
+    """Mapping from IDs to integer indices for users, items, and categories."""
+
+    user2index: dict[str, int]
+    item2index: dict[str, int]
+    category2index: dict[str, int]
+    item_index_2_category_index: dict[int, int]
+
+
+@dataclass(frozen=True)
+class AmazonReviewsPreprocessedResult:
+    """Container for preprocessed Amazon Reviews datasets and indices."""
+
+    train_df: pl.DataFrame
+    val_df: pl.DataFrame
+    test_df: pl.DataFrame
+    meta_df: pl.DataFrame
+    indices: AmazonReviewsIndices
+    user2index_df: pl.DataFrame
+    item2index_df: pl.DataFrame
+    category2index_df: pl.DataFrame
 
 
 def fetch_dataset(
@@ -102,12 +127,7 @@ def build_feature_indices(
     train_df: pl.DataFrame,
     meta_df: pl.DataFrame,
     threshold: float = 0.95,
-) -> tuple[
-    dict[str, int],  # user2index
-    dict[str, int],  # item2index
-    dict[str, int],  # category2index
-    dict[int, int],  # item_index_2_category_index
-]:
+) -> AmazonReviewsIndices:
     """Builds indices for users, items, and categories from the provided datasets.
 
     Args:
@@ -116,12 +136,7 @@ def build_feature_indices(
         threshold: The threshold for `unk_filter_by_count` to determine frequent users/items/categories. Defaults to 0.95.
 
     Returns:
-        A tuple containing:
-            - user2index: Mapping from user ID string to integer index.
-            - item2index: Mapping from item ID (parent_asin) string to integer index.
-            - category2index: Mapping from category string to integer index.
-            - item_index_2_category_index: Mapping from item integer index to category integer index.
-            - processed_train_df: The Polars DataFrame for training data after initial processing (conversion, metadata join, optional history filtering) from which indices were derived.
+        AmazonReviewsIndices: Mapping from IDs to integer indices.
     """
     # Assign unique ID to users, items and categories
     # 以下の条件を満たすUser/Item/CategoryはUNKに対応させるため、欠損させる。欠損したitemは後ほどUNKに対応させる
@@ -258,23 +273,17 @@ def build_feature_indices(
     ):
         item_index_2_category_index[item2index["#PAD"]] = SpecialCategoryIndex.PAD
 
-    return (
-        user2index,
-        item2index,
-        category2index,
-        item_index_2_category_index,
+    return AmazonReviewsIndices(
+        user2index=user2index,
+        item2index=item2index,
+        category2index=category2index,
+        item_index_2_category_index=item_index_2_category_index,
     )
 
 
-# TODO: Consider using a namedtuple for clarity in the return type
 def common_preprocess_dataset(
     dataset_dict: D.DatasetDict, metadata: D.Dataset, filter_no_history: bool = True
-) -> tuple[
-    tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame],
-    pl.DataFrame,
-    tuple[dict[str, int], dict[str, int], dict[str, int], dict[int, int]],
-    tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame],
-]:
+) -> AmazonReviewsPreprocessedResult:
     """Common preprocessing steps for the Amazon Reviews dataset.
 
     This function performs general preprocessing steps including:
@@ -290,11 +299,7 @@ def common_preprocess_dataset(
         filter_no_history: If True, filters out users with no interaction history. Defaults to True.
 
     Returns:
-        A tuple containing:
-            - (train_df, val_df, test_df): Tuple of preprocessed train, validation, and test DataFrames.
-            - meta_df: Preprocessed metadata DataFrame.
-            - (user2index, item2index, category2index, item_index_2_category_index): Tuple of dictionaries mapping features to integer indices.
-            - (user2index_df, item2index_df, category2index_df): Tuple of DataFrames corresponding to the indices.
+        AmazonReviewsPreprocessedResult: Container for preprocessed DataFrames and indices.
     """
     schema_overrides = {
         "user_id": pl.String,
@@ -327,31 +332,33 @@ def common_preprocess_dataset(
         val_df = val_df.filter(pl.col("history") != "")
         test_df = test_df.filter(pl.col("history") != "")
 
-    (
-        user2index,
-        item2index,
-        category2index,
-        item_index_2_category_index,
-    ) = build_feature_indices(train_df, meta_df, threshold=0.95)
+    indices = build_feature_indices(train_df, meta_df, threshold=0.95)
     user2index_df = pl.from_dict(
-        {"user_id": list(user2index.keys()), "user_index": list(user2index.values())}
+        {
+            "user_id": list(indices.user2index.keys()),
+            "user_index": list(indices.user2index.values()),
+        }
     )
     item2index_df = pl.from_dict(
         {
-            "parent_asin": list(item2index.keys()),
-            "item_index": list(item2index.values()),
+            "parent_asin": list(indices.item2index.keys()),
+            "item_index": list(indices.item2index.values()),
         }
     )
     category2index_df = pl.from_dict(
         {
-            "category": list(category2index.keys()),
-            "category_index": list(category2index.values()),
+            "category": list(indices.category2index.keys()),
+            "category_index": list(indices.category2index.values()),
         }
     )
 
-    return (
-        (train_df, val_df, test_df),
-        meta_df,
-        (user2index, item2index, category2index, item_index_2_category_index),
-        (user2index_df, item2index_df, category2index_df),
+    return AmazonReviewsPreprocessedResult(
+        train_df=train_df,
+        val_df=val_df,
+        test_df=test_df,
+        meta_df=meta_df,
+        indices=indices,
+        user2index_df=user2index_df,
+        item2index_df=item2index_df,
+        category2index_df=category2index_df,
     )

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/common.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/common.py
@@ -66,11 +66,14 @@ def fetch_dataset(
     logger.info("Fetching Amazon Reviews 2023 dataset")
     # NOTE: According to the benchmark script, last_out is widely used in research. But, it is not realistic.
     # https://github.com/hyp1231/AmazonReviews2023/tree/main/benchmark_scripts#rating_only---timestamp
-    dataset_dict: D.DatasetDict = D.load_dataset(
+    dataset_dict = D.load_dataset(
         "McAuley-Lab/Amazon-Reviews-2023",
         f"{dataset_type}_{category}",
         trust_remote_code=True,
     )
+    if not isinstance(dataset_dict, D.DatasetDict):
+        msg = f"Expected DatasetDict from load_dataset, got {type(dataset_dict).__name__}"
+        raise TypeError(msg)
     return dataset_dict
 
 
@@ -84,12 +87,15 @@ def fetch_metadata(category: str = "Video_Games") -> D.Dataset:
         datasets.Dataset, Dataset Schema is the following: https://huggingface.co/datasets/McAuley-Lab/Amazon-Reviews-2023#for-item-metadata
     """
     logger.info("Fetching Amazon Reviews 2023 metadata")
-    metadata: D.Dataset = D.load_dataset(
+    metadata = D.load_dataset(
         "McAuley-Lab/Amazon-Reviews-2023",
         f"raw_meta_{category}",
         split="full",
         trust_remote_code=True,
     )
+    if not isinstance(metadata, D.Dataset):
+        msg = f"Expected Dataset from load_dataset, got {type(metadata).__name__}"
+        raise TypeError(msg)
     return metadata
 
 

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/seq_rec.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/seq_rec.py
@@ -43,64 +43,6 @@ class AmazonReviewsSeqRecPreprocessedResult:
     item_index_2_metadata: dict[int, AmazonReviewsItemMetadata]
 
 
-def _normalize_cached_item_index_2_metadata(
-    raw_metadata: object,
-) -> tuple[dict[int, AmazonReviewsItemMetadata], bool]:
-    """Normalize cached item metadata to the current dataclass representation.
-
-    Args:
-        raw_metadata: Unpickled payload loaded from ``item_index_2_metadata.pkl``.
-
-    Returns:
-        A tuple containing the normalized metadata mapping and whether a legacy
-        cache payload was migrated.
-
-    Raises:
-        KeyError: If a legacy cache entry is missing one of the required fields.
-        TypeError: If the cached payload shape is unsupported.
-    """
-    if not isinstance(raw_metadata, dict):
-        raise TypeError(
-            "Invalid cached item_index_2_metadata.pkl: expected dict, "
-            f"got {type(raw_metadata).__name__}"
-        )
-
-    normalized_metadata: dict[int, AmazonReviewsItemMetadata] = {}
-    migrated = False
-    for item_index, metadata in raw_metadata.items():
-        if not isinstance(item_index, int):
-            raise TypeError(
-                "Invalid cached item_index_2_metadata.pkl: expected integer keys, "
-                f"got {type(item_index).__name__}"
-            )
-
-        if isinstance(metadata, AmazonReviewsItemMetadata):
-            normalized_metadata[item_index] = metadata
-            continue
-
-        if not isinstance(metadata, dict):
-            raise TypeError(
-                "Invalid cached item_index_2_metadata.pkl: expected values of type "
-                "AmazonReviewsItemMetadata or legacy dict payloads."
-            )
-
-        missing_fields = {"category_index", "average_rating", "rating_number"} - metadata.keys()
-        if missing_fields:
-            raise KeyError(
-                "Invalid cached item_index_2_metadata.pkl: missing fields "
-                f"{sorted(missing_fields)} for item_index={item_index}"
-            )
-
-        normalized_metadata[item_index] = AmazonReviewsItemMetadata(
-            category_index=int(metadata["category_index"]),
-            average_rating=float(metadata["average_rating"]),
-            rating_number=int(metadata["rating_number"]),
-        )
-        migrated = True
-
-    return normalized_metadata, migrated
-
-
 def seq_rec_preprocess_dataset(
     dataset_dict: D.DatasetDict, metadata: D.Dataset, filter_no_history: bool = True
 ) -> AmazonReviewsSeqRecPreprocessedResult:
@@ -631,17 +573,7 @@ class AmazonReviewsSeqRecDataModule(L.LightningDataModule):
             with open(category2index_path, "rb") as f:
                 self.category2index: dict[str, int] = pickle.load(f)
             with open(item_index_2_metadata_path, "rb") as f:
-                raw_item_index_2_metadata = pickle.load(f)
-            self.item_index_2_metadata, migrated = _normalize_cached_item_index_2_metadata(
-                raw_item_index_2_metadata
-            )
-            if migrated:
-                logger.warning(
-                    "Detected legacy cached item_index_2_metadata.pkl format; "
-                    "migrating to AmazonReviewsItemMetadata."
-                )
-                with open(item_index_2_metadata_path, "wb") as f:
-                    pickle.dump(self.item_index_2_metadata, f)
+                self.item_index_2_metadata: dict[int, AmazonReviewsItemMetadata] = pickle.load(f)
         else:
             if not self.save_dir.exists():
                 self.save_dir.mkdir(parents=True)

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/seq_rec.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/seq_rec.py
@@ -1,6 +1,7 @@
 import pathlib
 import pickle
-from typing import Any, NamedTuple
+from dataclasses import dataclass
+from typing import NamedTuple
 
 import datasets as D
 import lightning as L
@@ -12,6 +13,7 @@ from loguru import logger
 from torch.utils.data import DataLoader, Dataset
 
 from .common import (
+    AmazonReviewsIndices,
     SpecialCategoryIndex,
     SpecialItemIndex,
     SpecialUserIndex,
@@ -21,17 +23,29 @@ from .common import (
 )
 
 
+@dataclass(frozen=True)
+class AmazonReviewsItemMetadata:
+    """Static metadata used for item-level negative sampling."""
+
+    category_index: int
+    average_rating: float
+    rating_number: int
+
+
+@dataclass(frozen=True)
+class AmazonReviewsSeqRecPreprocessedResult:
+    """Container for preprocessed sequential recommendation artifacts."""
+
+    train_df: pl.DataFrame
+    val_df: pl.DataFrame
+    test_df: pl.DataFrame
+    indices: AmazonReviewsIndices
+    item_index_2_metadata: dict[int, AmazonReviewsItemMetadata]
+
+
 def seq_rec_preprocess_dataset(
     dataset_dict: D.DatasetDict, metadata: D.Dataset, filter_no_history: bool = True
-) -> tuple[
-    pl.DataFrame,
-    pl.DataFrame,
-    pl.DataFrame,
-    dict[str, int],
-    dict[str, int],
-    dict[str, int],
-    dict[int, dict[str, Any]],
-]:
+) -> AmazonReviewsSeqRecPreprocessedResult:
     """Preprocess the dataset for Sequential Recommendation.
 
     This function performs common preprocessing (converting to Polars, joining metadata, filtering)
@@ -46,25 +60,22 @@ def seq_rec_preprocess_dataset(
         filter_no_history: If True, filters out users with no interaction history. Defaults to True.
 
     Returns:
-        A tuple containing:
-            - train_df: Preprocessed training DataFrame.
-            - val_df: Preprocessed validation DataFrame.
-            - test_df: Preprocessed test DataFrame.
-            - user2index: Mapping from user ID to integer index.
-            - item2index: Mapping from item ID (parent_asin) to integer index.
-            - category2index: Mapping from category name to integer index.
-            - item_index_2_metadata: Mapping from item integer index to its metadata dict
-                (containing 'category_index', 'average_rating', 'rating_number').
+        AmazonReviewsSeqRecPreprocessedResult: Container for preprocessed
+            train/validation/test dataframes, feature indices, and item metadata.
     """
-    (
-        (train_df, val_df, test_df),
-        meta_df,
-        (user2index, item2index, category2index, item_index_2_category_index),
-        (user2index_df, item2index_df, category2index_df),
-    ) = common_preprocess_dataset(
+    processed = common_preprocess_dataset(
         dataset_dict=dataset_dict,
         metadata=metadata,
         filter_no_history=filter_no_history,
+    )
+    train_df, val_df, test_df = processed.train_df, processed.val_df, processed.test_df
+    meta_df = processed.meta_df
+    indices = processed.indices
+    item_index_2_category_index = indices.item_index_2_category_index
+    user2index_df, item2index_df, category2index_df = (
+        processed.user2index_df,
+        processed.item2index_df,
+        processed.category2index_df,
     )
 
     # preprocess
@@ -228,30 +239,39 @@ def seq_rec_preprocess_dataset(
     )
 
     metadata_map = {
-        row["item_index"]: {
-            "average_rating": row["average_rating"],
-            "rating_number": row["rating_number"],
-        }
+        row["item_index"]: AmazonReviewsItemMetadata(
+            category_index=item_index_2_category_index.get(
+                row["item_index"],
+                int(SpecialCategoryIndex.UNK),
+            ),
+            average_rating=row["average_rating"],
+            rating_number=row["rating_number"],
+        )
         for row in item_metadata_df.iter_rows(named=True)
     }
 
-    item_index_2_metadata: dict[int, dict[str, Any]] = {}
+    item_index_2_metadata: dict[int, AmazonReviewsItemMetadata] = {}
     for item_index, category_index in item_index_2_category_index.items():
-        meta = metadata_map.get(item_index, {"average_rating": 0.0, "rating_number": 0})
-        item_index_2_metadata[item_index] = {
-            "category_index": category_index,
-            "average_rating": meta["average_rating"],
-            "rating_number": meta["rating_number"],
-        }
+        meta = metadata_map.get(
+            item_index,
+            AmazonReviewsItemMetadata(
+                category_index=category_index,
+                average_rating=0.0,
+                rating_number=0,
+            ),
+        )
+        item_index_2_metadata[item_index] = AmazonReviewsItemMetadata(
+            category_index=category_index,
+            average_rating=meta.average_rating,
+            rating_number=meta.rating_number,
+        )
 
-    return (
-        train_df,
-        val_df,
-        test_df,
-        user2index,
-        item2index,
-        category2index,
-        item_index_2_metadata,
+    return AmazonReviewsSeqRecPreprocessedResult(
+        train_df=train_df,
+        val_df=val_df,
+        test_df=test_df,
+        indices=indices,
+        item_index_2_metadata=item_index_2_metadata,
     )
 
 
@@ -440,14 +460,17 @@ class AmazonReviewsSeqRecDataModule(L.LightningDataModule):
         """Amazon Reviews Data Module for Sequential Recommendation
 
         Args:
-            save_dir: save directory for preprocessed dataset
-            batch_size: batch size. Defaults to 32.
-            num_workers: number of workers. Defaults to 2.
-            max_seq_len: maximum sequence length. Defaults to 50.
-            neg_sample_size: negative sample size. Defaults to 1.
-            sampling_val_test: whether to sample validation and test dataset. Defaults to False.
-            eval_negative_sample_size: negative sample size for evaluation. Defaults to 100.
-            filter_no_history: whether to filter out the dataset which has no history. Defaults to True.
+            save_dir: Save directory for preprocessed dataset.
+            batch_size: Batch size. Defaults to 32.
+            num_workers: Number of workers. Defaults to 2.
+            max_seq_len: Maximum sequence length. Defaults to 50.
+            neg_sample_size: Negative sample size. Defaults to 1.
+            sampling_val_test: Whether to sample validation and test dataset.
+                Defaults to False.
+            eval_negative_sample_size: Negative sample size for evaluation.
+                Defaults to 100.
+            filter_no_history: Whether to filter out the dataset which has no
+                history. Defaults to True.
         """
         super().__init__()
         self.save_dir = save_dir
@@ -566,7 +589,7 @@ class AmazonReviewsSeqRecDataModule(L.LightningDataModule):
             with open(category2index_path, "rb") as f:
                 self.category2index: dict[str, int] = pickle.load(f)
             with open(item_index_2_metadata_path, "rb") as f:
-                self.item_index_2_metadata: dict[int, dict[str, Any]] = pickle.load(f)
+                self.item_index_2_metadata: dict[int, AmazonReviewsItemMetadata] = pickle.load(f)
         else:
             if not self.save_dir.exists():
                 self.save_dir.mkdir(parents=True)
@@ -574,17 +597,16 @@ class AmazonReviewsSeqRecDataModule(L.LightningDataModule):
             logger.info("Preprocessed dataset not found")
             dataset_dict = fetch_dataset()
             metadata = fetch_metadata()
-            (
-                self.train_df,
-                self.val_df,
-                self.test_df,
-                self.user2index,
-                self.item2index,
-                self.category2index,
-                self.item_index_2_metadata,
-            ) = seq_rec_preprocess_dataset(
+            processed = seq_rec_preprocess_dataset(
                 dataset_dict, metadata, filter_no_history=self.filter_no_history
             )
+            self.train_df = processed.train_df
+            self.val_df = processed.val_df
+            self.test_df = processed.test_df
+            self.user2index = processed.indices.user2index
+            self.item2index = processed.indices.item2index
+            self.category2index = processed.indices.category2index
+            self.item_index_2_metadata = processed.item_index_2_metadata
 
             # save
             self.train_df.write_parquet(train_path)
@@ -609,13 +631,13 @@ class AmazonReviewsSeqRecDataModule(L.LightningDataModule):
             {
                 "item_index": list(self.item_index_2_metadata.keys()),
                 "category_index": [
-                    meta["category_index"] for meta in self.item_index_2_metadata.values()
+                    meta.category_index for meta in self.item_index_2_metadata.values()
                 ],
                 "average_rating": [
-                    meta["average_rating"] for meta in self.item_index_2_metadata.values()
+                    meta.average_rating for meta in self.item_index_2_metadata.values()
                 ],
                 "rating_number": [
-                    meta["rating_number"] for meta in self.item_index_2_metadata.values()
+                    meta.rating_number for meta in self.item_index_2_metadata.values()
                 ],
             }
         )

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/seq_rec.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/seq_rec.py
@@ -43,6 +43,64 @@ class AmazonReviewsSeqRecPreprocessedResult:
     item_index_2_metadata: dict[int, AmazonReviewsItemMetadata]
 
 
+def _normalize_cached_item_index_2_metadata(
+    raw_metadata: object,
+) -> tuple[dict[int, AmazonReviewsItemMetadata], bool]:
+    """Normalize cached item metadata to the current dataclass representation.
+
+    Args:
+        raw_metadata: Unpickled payload loaded from ``item_index_2_metadata.pkl``.
+
+    Returns:
+        A tuple containing the normalized metadata mapping and whether a legacy
+        cache payload was migrated.
+
+    Raises:
+        KeyError: If a legacy cache entry is missing one of the required fields.
+        TypeError: If the cached payload shape is unsupported.
+    """
+    if not isinstance(raw_metadata, dict):
+        raise TypeError(
+            "Invalid cached item_index_2_metadata.pkl: expected dict, "
+            f"got {type(raw_metadata).__name__}"
+        )
+
+    normalized_metadata: dict[int, AmazonReviewsItemMetadata] = {}
+    migrated = False
+    for item_index, metadata in raw_metadata.items():
+        if not isinstance(item_index, int):
+            raise TypeError(
+                "Invalid cached item_index_2_metadata.pkl: expected integer keys, "
+                f"got {type(item_index).__name__}"
+            )
+
+        if isinstance(metadata, AmazonReviewsItemMetadata):
+            normalized_metadata[item_index] = metadata
+            continue
+
+        if not isinstance(metadata, dict):
+            raise TypeError(
+                "Invalid cached item_index_2_metadata.pkl: expected values of type "
+                "AmazonReviewsItemMetadata or legacy dict payloads."
+            )
+
+        missing_fields = {"category_index", "average_rating", "rating_number"} - metadata.keys()
+        if missing_fields:
+            raise KeyError(
+                "Invalid cached item_index_2_metadata.pkl: missing fields "
+                f"{sorted(missing_fields)} for item_index={item_index}"
+            )
+
+        normalized_metadata[item_index] = AmazonReviewsItemMetadata(
+            category_index=int(metadata["category_index"]),
+            average_rating=float(metadata["average_rating"]),
+            rating_number=int(metadata["rating_number"]),
+        )
+        migrated = True
+
+    return normalized_metadata, migrated
+
+
 def seq_rec_preprocess_dataset(
     dataset_dict: D.DatasetDict, metadata: D.Dataset, filter_no_history: bool = True
 ) -> AmazonReviewsSeqRecPreprocessedResult:
@@ -250,28 +308,12 @@ def seq_rec_preprocess_dataset(
         for row in item_metadata_df.iter_rows(named=True)
     }
 
-    item_index_2_metadata: dict[int, AmazonReviewsItemMetadata] = {}
-    for item_index, category_index in item_index_2_category_index.items():
-        meta = metadata_map.get(
-            item_index,
-            AmazonReviewsItemMetadata(
-                category_index=category_index,
-                average_rating=0.0,
-                rating_number=0,
-            ),
-        )
-        item_index_2_metadata[item_index] = AmazonReviewsItemMetadata(
-            category_index=category_index,
-            average_rating=meta.average_rating,
-            rating_number=meta.rating_number,
-        )
-
     return AmazonReviewsSeqRecPreprocessedResult(
         train_df=train_df,
         val_df=val_df,
         test_df=test_df,
         indices=indices,
-        item_index_2_metadata=item_index_2_metadata,
+        item_index_2_metadata=metadata_map,
     )
 
 
@@ -589,7 +631,17 @@ class AmazonReviewsSeqRecDataModule(L.LightningDataModule):
             with open(category2index_path, "rb") as f:
                 self.category2index: dict[str, int] = pickle.load(f)
             with open(item_index_2_metadata_path, "rb") as f:
-                self.item_index_2_metadata: dict[int, AmazonReviewsItemMetadata] = pickle.load(f)
+                raw_item_index_2_metadata = pickle.load(f)
+            self.item_index_2_metadata, migrated = _normalize_cached_item_index_2_metadata(
+                raw_item_index_2_metadata
+            )
+            if migrated:
+                logger.warning(
+                    "Detected legacy cached item_index_2_metadata.pkl format; "
+                    "migrating to AmazonReviewsItemMetadata."
+                )
+                with open(item_index_2_metadata_path, "wb") as f:
+                    pickle.dump(self.item_index_2_metadata, f)
         else:
             if not self.save_dir.exists():
                 self.save_dir.mkdir(parents=True)

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/factory.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/factory.py
@@ -23,7 +23,8 @@ def create_seq_rec_datamodule(
         max_seq_len: Maximum user-history sequence length.
         neg_sample_size: Number of negative samples used during training.
         num_workers: Number of dataloader worker processes.
-        eval_negative_sample_size: Number of negative samples used for validation and test.
+        eval_negative_sample_size: Number of negative samples used for
+            validation and test.
 
     Returns:
         AmazonReviewsSeqRecDataModule: Instantiated datamodule.

--- a/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_bipartite.py
+++ b/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_bipartite.py
@@ -1,5 +1,4 @@
 import pathlib
-from typing import Any
 
 import polars as pl
 import pytest
@@ -10,6 +9,9 @@ from torch_geometric.loader import LinkNeighborLoader
 from torch_geometric.sampler import NegativeSampling
 
 from ml_sandbox_libs.data.amazon_reviews_dataset import (
+    AmazonReviewsBipartiteGraphPreprocessedResult,
+    AmazonReviewsIndices,
+    AmazonReviewsPreprocessedResult,
     SpecialCategoryIndex,
     SpecialItemIndex,
     SpecialUserIndex,
@@ -32,7 +34,9 @@ def _edge_pairs_with_attr(
     )
 
 
-def _build_common_preprocess_return(*, duplicate_across_splits: bool = False) -> tuple[Any, ...]:
+def _build_common_preprocess_return(
+    *, duplicate_across_splits: bool = False
+) -> AmazonReviewsPreprocessedResult:
     train_items = ["item1", "item2", "item3"]
     if duplicate_across_splits:
         val_items = ["item1", "item5", "item6"]
@@ -156,15 +160,26 @@ def _build_common_preprocess_return(*, duplicate_across_splits: bool = False) ->
         }
     )
 
-    return (
-        (train_df, val_df, test_df),
-        meta_df,
-        (user2index, item2index, category2index, item_index_2_category_index),
-        (user2index_df, item2index_df, category2index_df),
+    return AmazonReviewsPreprocessedResult(
+        train_df=train_df,
+        val_df=val_df,
+        test_df=test_df,
+        meta_df=meta_df,
+        indices=AmazonReviewsIndices(
+            user2index=user2index,
+            item2index=item2index,
+            category2index=category2index,
+            item_index_2_category_index=item_index_2_category_index,
+        ),
+        user2index_df=user2index_df,
+        item2index_df=item2index_df,
+        category2index_df=category2index_df,
     )
 
 
-def _build_preprocessed_graph_inputs(mocker: MockerFixture) -> tuple[Any, ...]:
+def _build_preprocessed_graph_inputs(
+    mocker: MockerFixture,
+) -> AmazonReviewsBipartiteGraphPreprocessedResult:
     mock_dataset_dict = mocker.Mock()
     mock_metadata = mocker.Mock()
     common_preprocess_return = _build_common_preprocess_return()
@@ -186,9 +201,12 @@ def test_bipartite_graph_preprocess_dataset_returns_expected_dataframe(
         return_value=common_preprocess_return,
     )
 
-    all_df, user2index, item2index, category2index, item_index_2_category_index = (
-        bipartite_graph_preprocess_dataset(mock_dataset_dict, mock_metadata)
-    )
+    result = bipartite_graph_preprocess_dataset(mock_dataset_dict, mock_metadata)
+    all_df = result.all_df
+    user2index = result.indices.user2index
+    item2index = result.indices.item2index
+    category2index = result.indices.category2index
+    item_index_2_category_index = result.indices.item_index_2_category_index
 
     assert all_df.columns == [
         "split",
@@ -254,13 +272,11 @@ def test_create_bipartite_graph_uses_expected_message_passing_and_label_edges(
     expected_message_passing_edges: list[tuple[int, int, float]],
     expected_label_edges: list[tuple[int, int, float]],
 ) -> None:
-    (
-        all_df,
-        user2index,
-        item2index,
-        _category2index,
-        item_index_2_category_index,
-    ) = _build_preprocessed_graph_inputs(mocker)
+    processed = _build_preprocessed_graph_inputs(mocker)
+    all_df = processed.all_df
+    user2index = processed.indices.user2index
+    item2index = processed.indices.item2index
+    item_index_2_category_index = processed.indices.item_index_2_category_index
 
     data = create_bipartite_graph(
         split=split,  # type: ignore[arg-type]
@@ -293,13 +309,11 @@ def test_create_bipartite_graph_uses_expected_message_passing_and_label_edges(
 
 
 def test_create_bipartite_graph_rejects_invalid_split(mocker: MockerFixture) -> None:
-    (
-        all_df,
-        user2index,
-        item2index,
-        _category2index,
-        item_index_2_category_index,
-    ) = _build_preprocessed_graph_inputs(mocker)
+    processed = _build_preprocessed_graph_inputs(mocker)
+    all_df = processed.all_df
+    user2index = processed.indices.user2index
+    item2index = processed.indices.item2index
+    item_index_2_category_index = processed.indices.item_index_2_category_index
 
     with pytest.raises(ValueError, match="Invalid split"):
         create_bipartite_graph(
@@ -333,11 +347,11 @@ def test_bipartite_graph_datamodule_prepare_data_populates_state(
     dm = AmazonReviewsBipartiteGraphDataModule(save_dir=tmp_path)
     dm.prepare_data()
 
-    assert dm.all_df.equals(preprocess_return[0])
-    assert dm.user2index == preprocess_return[1]
-    assert dm.item2index == preprocess_return[2]
-    assert dm.category2index == preprocess_return[3]
-    assert dm.item_index_2_category_index == preprocess_return[4]
+    assert dm.all_df.equals(preprocess_return.all_df)
+    assert dm.user2index == preprocess_return.indices.user2index
+    assert dm.item2index == preprocess_return.indices.item2index
+    assert dm.category2index == preprocess_return.indices.category2index
+    assert dm.item_index_2_category_index == preprocess_return.indices.item_index_2_category_index
     preprocess_mock.assert_called_once_with(dataset_dict=mock_dataset_dict, metadata=mock_metadata)
 
 
@@ -377,13 +391,11 @@ def test_bipartite_graph_datamodule_setup_creates_expected_graphs(
     # This test focuses on split-specific graph construction. Disable PyG transforms
     # so node reindexing does not obscure the expected edge assignments.
     dm.transform = lambda data: data  # type: ignore[assignment]
-    (
-        dm.all_df,
-        dm.user2index,
-        dm.item2index,
-        dm.category2index,
-        dm.item_index_2_category_index,
-    ) = preprocess_return
+    dm.all_df = preprocess_return.all_df
+    dm.user2index = preprocess_return.indices.user2index
+    dm.item2index = preprocess_return.indices.item2index
+    dm.category2index = preprocess_return.indices.category2index
+    dm.item_index_2_category_index = preprocess_return.indices.item_index_2_category_index
 
     dm.setup("fit")
     assert _edge_pairs_with_attr(
@@ -422,17 +434,18 @@ def test_bipartite_graph_datamodule_dataloaders_use_stage_specific_label_edges(
     mocker: MockerFixture, tmp_path: pathlib.Path
 ) -> None:
     preprocess_return = _build_preprocessed_graph_inputs(mocker)
-    dm = AmazonReviewsBipartiteGraphDataModule(save_dir=tmp_path, num_neighbors=[7, 3])
+    dm = AmazonReviewsBipartiteGraphDataModule(
+        save_dir=tmp_path,
+        num_neighbors=(7, 3),
+    )
     # This test verifies which graph and label edges each loader uses, not the
     # behavior of the PyG transforms applied during setup.
     dm.transform = lambda data: data  # type: ignore[assignment]
-    (
-        dm.all_df,
-        dm.user2index,
-        dm.item2index,
-        dm.category2index,
-        dm.item_index_2_category_index,
-    ) = preprocess_return
+    dm.all_df = preprocess_return.all_df
+    dm.user2index = preprocess_return.indices.user2index
+    dm.item2index = preprocess_return.indices.item2index
+    dm.category2index = preprocess_return.indices.category2index
+    dm.item_index_2_category_index = preprocess_return.indices.item_index_2_category_index
     dm.setup("fit")
     dm.setup("test")
 

--- a/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_bipartite_graph.py
+++ b/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_bipartite_graph.py
@@ -2,9 +2,7 @@ import pathlib
 
 import pytest
 
-from ml_sandbox_libs.data.amazon_reviews_dataset.bipartite_graph import (
-    AmazonReviewsBipartiteGraphDataModule,
-)
+from ml_sandbox_libs.data.amazon_reviews_dataset import AmazonReviewsBipartiteGraphDataModule
 
 
 def test_bipartite_graph_datamodule_num_users_and_num_items_require_initialized_indices(

--- a/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_common.py
+++ b/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_common.py
@@ -48,9 +48,10 @@ def test_build_feature_indices() -> None:
     meta_df = pl.from_dict(metadata_data)
 
     # Call the function with DataFrames directly
-    user2index, item2index, category2index, item_index_2_category_index = build_feature_indices(
-        train_df, meta_df, threshold=0.8
-    )
+    indices = build_feature_indices(train_df, meta_df, threshold=0.8)
+    user2index, item2index = indices.user2index, indices.item2index
+    category2index = indices.category2index
+    item_index_2_category_index = indices.item_index_2_category_index
 
     # Verify results
     # Check that special indices are included

--- a/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_common.py
+++ b/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_common.py
@@ -1,4 +1,7 @@
+import datasets as D
 import polars as pl
+import pytest
+from pytest_mock import MockerFixture
 
 from ml_sandbox_libs.data.amazon_reviews_dataset import (
     SpecialCategoryIndex,
@@ -7,6 +10,8 @@ from ml_sandbox_libs.data.amazon_reviews_dataset import (
 )
 from ml_sandbox_libs.data.amazon_reviews_dataset.common import (
     build_feature_indices,
+    fetch_dataset,
+    fetch_metadata,
     unk_filter_by_count,
 )
 
@@ -81,3 +86,53 @@ def test_build_feature_indices() -> None:
     # Check that special indices map correctly
     assert item_index_2_category_index[item2index["#UNK"]] == SpecialCategoryIndex.UNK
     assert item_index_2_category_index[item2index["#PAD"]] == SpecialCategoryIndex.PAD
+
+
+def test_fetch_dataset_returns_dataset_dict(mocker: MockerFixture) -> None:
+    """Return a DatasetDict when datasets.load_dataset provides the expected type."""
+    dataset_dict = D.DatasetDict({"train": D.Dataset.from_dict({"value": [1]})})
+    load_dataset_mock = mocker.patch(
+        "ml_sandbox_libs.data.amazon_reviews_dataset.common.D.load_dataset",
+        return_value=dataset_dict,
+    )
+
+    result = fetch_dataset()
+
+    assert result is dataset_dict
+    load_dataset_mock.assert_called_once()
+
+
+def test_fetch_dataset_raises_for_unexpected_dataset_type(mocker: MockerFixture) -> None:
+    """Reject non-DatasetDict values returned by datasets.load_dataset."""
+    mocker.patch(
+        "ml_sandbox_libs.data.amazon_reviews_dataset.common.D.load_dataset",
+        return_value=D.Dataset.from_dict({"value": [1]}),
+    )
+
+    with pytest.raises(TypeError, match="Expected DatasetDict"):
+        fetch_dataset()
+
+
+def test_fetch_metadata_returns_dataset(mocker: MockerFixture) -> None:
+    """Return a Dataset when datasets.load_dataset provides the expected type."""
+    dataset = D.Dataset.from_dict({"value": [1]})
+    load_dataset_mock = mocker.patch(
+        "ml_sandbox_libs.data.amazon_reviews_dataset.common.D.load_dataset",
+        return_value=dataset,
+    )
+
+    result = fetch_metadata()
+
+    assert result is dataset
+    load_dataset_mock.assert_called_once()
+
+
+def test_fetch_metadata_raises_for_unexpected_dataset_type(mocker: MockerFixture) -> None:
+    """Reject non-Dataset values returned by datasets.load_dataset."""
+    mocker.patch(
+        "ml_sandbox_libs.data.amazon_reviews_dataset.common.D.load_dataset",
+        return_value=D.DatasetDict({"train": D.Dataset.from_dict({"value": [1]})}),
+    )
+
+    with pytest.raises(TypeError, match="Expected Dataset"):
+        fetch_metadata()

--- a/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_seq_rec.py
+++ b/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_seq_rec.py
@@ -1,5 +1,4 @@
 import pathlib
-import pickle
 
 import polars as pl
 import pytest
@@ -360,39 +359,3 @@ def test_negative_sampling_has_average_rating(
 
     # Check types
     assert neg_average_ratings.dtype == torch.float32
-
-
-def test_prepare_data_migrates_legacy_item_metadata_cache(tmp_path: pathlib.Path) -> None:
-    """Migrate legacy cached item metadata dictionaries to typed dataclasses."""
-    dummy_df = pl.DataFrame({"user_index": [1], "item_index": [2]})
-    for split in ("train", "val", "test"):
-        dummy_df.write_parquet(tmp_path / f"{split}.parquet")
-
-    with open(tmp_path / "user2index.pkl", "wb") as f:
-        pickle.dump({"#UNK": 0, "user_a": 1}, f)
-    with open(tmp_path / "item2index.pkl", "wb") as f:
-        pickle.dump({"#PAD": 0, "#UNK": 1, "item_a": 2}, f)
-    with open(tmp_path / "category2index.pkl", "wb") as f:
-        pickle.dump({"#PAD": 0, "#UNK": 1, "category_a": 2}, f)
-
-    legacy_item_metadata = {
-        0: {"category_index": 0, "average_rating": 0.0, "rating_number": 0},
-        1: {"category_index": 1, "average_rating": 0.0, "rating_number": 0},
-        2: {"category_index": 2, "average_rating": 4.5, "rating_number": 10},
-    }
-    item_metadata_path = tmp_path / "item_index_2_metadata.pkl"
-    with open(item_metadata_path, "wb") as f:
-        pickle.dump(legacy_item_metadata, f)
-
-    dm = AmazonReviewsSeqRecDataModule(save_dir=tmp_path)
-
-    dm.prepare_data()
-
-    assert dm.item_index_2_metadata[2] == AmazonReviewsItemMetadata(
-        category_index=2,
-        average_rating=4.5,
-        rating_number=10,
-    )
-    with open(item_metadata_path, "rb") as f:
-        migrated_item_metadata = pickle.load(f)
-    assert isinstance(migrated_item_metadata[2], AmazonReviewsItemMetadata)

--- a/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_seq_rec.py
+++ b/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_seq_rec.py
@@ -6,6 +6,10 @@ import torch
 from pytest_mock import MockerFixture
 
 from ml_sandbox_libs.data.amazon_reviews_dataset import (
+    AmazonReviewsIndices,
+    AmazonReviewsItemMetadata,
+    AmazonReviewsPreprocessedResult,
+    AmazonReviewsSeqRecPreprocessedResult,
     SpecialCategoryIndex,
     SpecialItemIndex,
     SpecialUserIndex,
@@ -146,11 +150,20 @@ def test_seq_rec_preprocess_dataset(mocker: MockerFixture) -> None:
     )
 
     # Mock common_preprocess_dataset
-    mock_common_preprocess_return = (
-        (mock_train_df, mock_val_df, mock_test_df),
-        mock_meta_df,
-        (mock_user2index, mock_item2index, mock_category2index, mock_item_index_2_category_index),
-        (mock_user2index_df, mock_item2index_df, mock_category2index_df),
+    mock_common_preprocess_return = AmazonReviewsPreprocessedResult(
+        train_df=mock_train_df,
+        val_df=mock_val_df,
+        test_df=mock_test_df,
+        meta_df=mock_meta_df,
+        indices=AmazonReviewsIndices(
+            user2index=mock_user2index,
+            item2index=mock_item2index,
+            category2index=mock_category2index,
+            item_index_2_category_index=mock_item_index_2_category_index,
+        ),
+        user2index_df=mock_user2index_df,
+        item2index_df=mock_item2index_df,
+        category2index_df=mock_category2index_df,
     )
 
     mock_common_preprocess_func = mocker.patch(
@@ -161,15 +174,11 @@ def test_seq_rec_preprocess_dataset(mocker: MockerFixture) -> None:
     # Test with filter_no_history=True (default)
     result = seq_rec_preprocess_dataset(mock_dataset_dict, mock_metadata, filter_no_history=True)
 
-    (
-        train_df,
-        val_df,
-        test_df,
-        user2index,
-        item2index,
-        category2index,
-        item_index_2_metadata,
-    ) = result
+    train_df, val_df, test_df = result.train_df, result.val_df, result.test_df
+    user2index = result.indices.user2index
+    item2index = result.indices.item2index
+    category2index = result.indices.category2index
+    item_index_2_metadata = result.item_index_2_metadata
 
     # Verify return types
     assert isinstance(train_df, pl.DataFrame)
@@ -183,8 +192,8 @@ def test_seq_rec_preprocess_dataset(mocker: MockerFixture) -> None:
     # Verify that indices are returned correctly
     assert user2index == mock_user2index
     assert item2index == mock_item2index
-    assert item_index_2_metadata[2]["category_index"] == mock_item_index_2_category_index[2]
-    assert item_index_2_metadata[2]["category_index"] == mock_item_index_2_category_index[2]
+    assert item_index_2_metadata[2].category_index == mock_item_index_2_category_index[2]
+    assert item_index_2_metadata[2].average_rating == 4.5
 
     # Verify expected columns in output DataFrames
     expected_columns = [
@@ -269,23 +278,29 @@ def test_negative_sampling_has_average_rating(
     dummy_item2index = {"i1": 2, "i2": 3, "h1": 4, "h2": 5, "h3": 6}
     dummy_category2index = {"c1": 2, "c2": 3, "c3": 4, "c4": 5, "c5": 6}
     dummy_item_index_2_metadata = {
-        2: {"category_index": 2, "average_rating": 4.5, "rating_number": 10},
-        3: {"category_index": 3, "average_rating": 3.5, "rating_number": 5},
-        4: {"category_index": 4, "average_rating": 3.0, "rating_number": 5},
-        5: {"category_index": 5, "average_rating": 4.0, "rating_number": 2},
-        6: {"category_index": 6, "average_rating": 2.5, "rating_number": 1},
+        2: AmazonReviewsItemMetadata(category_index=2, average_rating=4.5, rating_number=10),
+        3: AmazonReviewsItemMetadata(category_index=3, average_rating=3.5, rating_number=5),
+        4: AmazonReviewsItemMetadata(category_index=4, average_rating=3.0, rating_number=5),
+        5: AmazonReviewsItemMetadata(category_index=5, average_rating=4.0, rating_number=2),
+        6: AmazonReviewsItemMetadata(category_index=6, average_rating=2.5, rating_number=1),
     }
 
     mocker.patch(
         "ml_sandbox_libs.data.amazon_reviews_dataset.seq_rec.seq_rec_preprocess_dataset",
-        return_value=(
-            dummy_df,  # train
-            dummy_df,  # val
-            dummy_df,  # test
-            dummy_user2index,
-            dummy_item2index,
-            dummy_category2index,
-            dummy_item_index_2_metadata,
+        return_value=AmazonReviewsSeqRecPreprocessedResult(
+            train_df=dummy_df,
+            val_df=dummy_df,
+            test_df=dummy_df,
+            indices=AmazonReviewsIndices(
+                user2index=dummy_user2index,
+                item2index=dummy_item2index,
+                category2index=dummy_category2index,
+                item_index_2_category_index={
+                    item_index: metadata.category_index
+                    for item_index, metadata in dummy_item_index_2_metadata.items()
+                },
+            ),
+            item_index_2_metadata=dummy_item_index_2_metadata,
         ),
     )
 

--- a/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_seq_rec.py
+++ b/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_seq_rec.py
@@ -1,4 +1,5 @@
 import pathlib
+import pickle
 
 import polars as pl
 import pytest
@@ -359,3 +360,39 @@ def test_negative_sampling_has_average_rating(
 
     # Check types
     assert neg_average_ratings.dtype == torch.float32
+
+
+def test_prepare_data_migrates_legacy_item_metadata_cache(tmp_path: pathlib.Path) -> None:
+    """Migrate legacy cached item metadata dictionaries to typed dataclasses."""
+    dummy_df = pl.DataFrame({"user_index": [1], "item_index": [2]})
+    for split in ("train", "val", "test"):
+        dummy_df.write_parquet(tmp_path / f"{split}.parquet")
+
+    with open(tmp_path / "user2index.pkl", "wb") as f:
+        pickle.dump({"#UNK": 0, "user_a": 1}, f)
+    with open(tmp_path / "item2index.pkl", "wb") as f:
+        pickle.dump({"#PAD": 0, "#UNK": 1, "item_a": 2}, f)
+    with open(tmp_path / "category2index.pkl", "wb") as f:
+        pickle.dump({"#PAD": 0, "#UNK": 1, "category_a": 2}, f)
+
+    legacy_item_metadata = {
+        0: {"category_index": 0, "average_rating": 0.0, "rating_number": 0},
+        1: {"category_index": 1, "average_rating": 0.0, "rating_number": 0},
+        2: {"category_index": 2, "average_rating": 4.5, "rating_number": 10},
+    }
+    item_metadata_path = tmp_path / "item_index_2_metadata.pkl"
+    with open(item_metadata_path, "wb") as f:
+        pickle.dump(legacy_item_metadata, f)
+
+    dm = AmazonReviewsSeqRecDataModule(save_dir=tmp_path)
+
+    dm.prepare_data()
+
+    assert dm.item_index_2_metadata[2] == AmazonReviewsItemMetadata(
+        category_index=2,
+        average_rating=4.5,
+        rating_number=10,
+    )
+    with open(item_metadata_path, "rb") as f:
+        migrated_item_metadata = pickle.load(f)
+    assert isinstance(migrated_item_metadata[2], AmazonReviewsItemMetadata)

--- a/projects/recsys-candidate-generation/src/data/factory.py
+++ b/projects/recsys-candidate-generation/src/data/factory.py
@@ -35,7 +35,7 @@ def create_datamodule(
             neg_sample_size=cfg.data.neg_sample_size,
             num_workers=cfg.device.num_workers,
             eval_negative_sample_size=eval_negative_sample_size,
-            num_neighbors=list(cfg.model.get("num_neighbors", [10, 5])),
+            num_neighbors=tuple(cfg.model.get("num_neighbors", [10, 5])),
         )
 
     return AmazonReviewsSeqRecDataModule(

--- a/projects/recsys-candidate-generation/src/tests/test_data/test_data_factory.py
+++ b/projects/recsys-candidate-generation/src/tests/test_data/test_data_factory.py
@@ -58,7 +58,7 @@ def test_create_datamodule_builds_lightgcn_graph_datamodule(
         "neg_sample_size": cfg.data.neg_sample_size,
         "num_workers": cfg.device.num_workers,
         "eval_negative_sample_size": 100,
-        "num_neighbors": [9, 4],
+        "num_neighbors": (9, 4),
     }
 
 


### PR DESCRIPTION
## Summary
- replace tuple-heavy Amazon Reviews preprocessing returns with typed dataclasses in `ml_sandbox_libs`
- keep datamodule constructors on explicit kwargs while preserving the smaller data-typing improvements
- clean up seq-rec preprocessing and update downstream factories/tests to the final API

## Related Issues
- None

## Changes
- add typed preprocessing result containers and typed item metadata for Amazon Reviews data flows
- remove duplicate seq-rec join logic and drop the unused bipartite-only argument
- align shared and downstream call sites/tests with the explicit-kwargs datamodule constructors

## How to Test
- `cd libs/ml_sandbox_libs && make fmt && make lint && make test`
- `cd projects/recsys-ranking && make lint && make test`
- `cd projects/recsys-candidate-generation && make lint && make test`

## Additional Context
- The constructor config dataclasses introduced during the refactor were removed before opening this PR; only the narrower typing/cleanup changes remain.