### PR TITLE
[codex] Share fit runner across ranking and candidate-generation

### DIFF
--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/training/__init__.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/training/__init__.py
@@ -1,5 +1,6 @@
 """Training utilities subpackage for ml-sandbox-libs."""
 
 from .monitor import ExperimentMonitor, summarize_pos_neg_scores
+from .runner import run_training
 
-__all__ = ["ExperimentMonitor", "summarize_pos_neg_scores"]
+__all__ = ["ExperimentMonitor", "run_training", "summarize_pos_neg_scores"]

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/training/runner.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/training/runner.py
@@ -1,0 +1,45 @@
+"""Shared top-level training orchestration helpers."""
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import TypeVar
+
+import lightning as L
+import torch
+from loguru import logger
+from omegaconf import DictConfig
+
+from ml_sandbox_libs.models.base import BaseModule
+from ml_sandbox_libs.utils import setup_logger
+
+DataModuleT = TypeVar("DataModuleT", bound=L.LightningDataModule)
+
+
+def run_training(
+    cfg: DictConfig,
+    *,
+    prepare_datamodule: Callable[[DictConfig, Path], DataModuleT],
+    build_module: Callable[[DictConfig, DataModuleT], BaseModule],
+    build_trainer: Callable[[DictConfig, Path], L.Trainer],
+) -> None:
+    """Run the common top-level training flow for recommendation projects.
+
+    Args:
+        cfg: Hydra configuration object.
+        prepare_datamodule: Project-specific datamodule factory.
+        build_module: Project-specific model-module factory.
+        build_trainer: Project-specific trainer factory.
+    """
+    setup_logger()
+    logger.info(f"Starting the fit process with configuration: {cfg}")
+
+    if cfg.device.accelerator == "gpu":
+        torch.set_float32_matmul_precision("medium")
+
+    save_dir = Path(cfg.save_dir)
+    datamodule = prepare_datamodule(cfg, save_dir)
+    module = build_module(cfg, datamodule)
+    logger.info(module.summary(batch_size=cfg.data.batch_size))
+
+    trainer = build_trainer(cfg, save_dir)
+    trainer.fit(model=module, datamodule=datamodule)

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/training/runner.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/training/runner.py
@@ -1,5 +1,6 @@
 """Shared top-level training orchestration helpers."""
 
+import os
 from collections.abc import Callable
 from pathlib import Path
 from typing import TypeVar
@@ -13,6 +14,12 @@ from ml_sandbox_libs.models.base import BaseModule
 from ml_sandbox_libs.utils import setup_logger
 
 DataModuleT = TypeVar("DataModuleT", bound=L.LightningDataModule)
+
+
+def _should_log_model_summary() -> bool:
+    """Return whether the current process should emit shared summary logs."""
+    rank = os.environ.get("RANK") or os.environ.get("LOCAL_RANK")
+    return rank in (None, "", "0")
 
 
 def run_training(
@@ -30,16 +37,18 @@ def run_training(
         build_module: Project-specific model-module factory.
         build_trainer: Project-specific trainer factory.
     """
-    setup_logger()
+    save_dir = Path(cfg.save_dir)
+    save_dir.mkdir(parents=True, exist_ok=True)
+    setup_logger(log_path=save_dir / "training.log")
     logger.info(f"Starting the fit process with configuration: {cfg}")
 
     if cfg.device.accelerator == "gpu":
         torch.set_float32_matmul_precision("medium")
 
-    save_dir = Path(cfg.save_dir)
     datamodule = prepare_datamodule(cfg, save_dir)
     module = build_module(cfg, datamodule)
-    logger.info(module.summary(batch_size=cfg.data.batch_size))
+    if _should_log_model_summary():
+        logger.info(module.summary(batch_size=cfg.data.batch_size))
 
     trainer = build_trainer(cfg, save_dir)
     trainer.fit(model=module, datamodule=datamodule)

--- a/libs/ml_sandbox_libs/tests/test_training/test_runner.py
+++ b/libs/ml_sandbox_libs/tests/test_training/test_runner.py
@@ -1,8 +1,9 @@
 """Tests for the shared training runner."""
 
+import os
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 from omegaconf import OmegaConf
 from pytest_mock import MockerFixture
@@ -20,9 +21,9 @@ def test_run_training_executes_steps_in_order(mocker: MockerFixture, tmp_path: P
             "device": {"accelerator": "cpu"},
         }
     )
-    datamodule = SimpleNamespace()
-    module = SimpleNamespace(summary=mocker.Mock(return_value="model-summary"))
-    trainer = SimpleNamespace(fit=mocker.Mock())
+    datamodule = cast(Any, SimpleNamespace())
+    module = cast(Any, SimpleNamespace(summary=mocker.Mock(return_value="model-summary")))
+    trainer = cast(Any, SimpleNamespace(fit=mocker.Mock()))
     steps: list[str] = []
 
     def prepare_datamodule(cfg_arg: Any, save_dir_arg: Path) -> Any:
@@ -44,7 +45,9 @@ def test_run_training_executes_steps_in_order(mocker: MockerFixture, tmp_path: P
         return trainer
 
     setup_logger = mocker.patch("ml_sandbox_libs.training.runner.setup_logger")
+    mkdir = mocker.patch("pathlib.Path.mkdir")
     set_matmul_precision = mocker.patch("ml_sandbox_libs.training.runner.torch.set_float32_matmul_precision")
+    logger = mocker.patch("ml_sandbox_libs.training.runner.logger")
 
     run_training(
         cfg,
@@ -54,7 +57,40 @@ def test_run_training_executes_steps_in_order(mocker: MockerFixture, tmp_path: P
     )
 
     assert steps == ["prepare_datamodule", "build_module", "build_trainer"]
-    setup_logger.assert_called_once_with()
+    mkdir.assert_called_once_with(parents=True, exist_ok=True)
+    setup_logger.assert_called_once_with(log_path=tmp_path / "training.log")
     set_matmul_precision.assert_not_called()
     module.summary.assert_called_once_with(batch_size=cfg.data.batch_size)
     trainer.fit.assert_called_once_with(model=module, datamodule=datamodule)
+    assert logger.info.call_count >= 2
+
+
+def test_run_training_skips_model_summary_logging_on_nonzero_rank(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Skip the shared model summary log on non-primary distributed ranks."""
+    cfg = OmegaConf.create(
+        {
+            "save_dir": str(tmp_path),
+            "debug": False,
+            "data": {"batch_size": 32},
+            "device": {"accelerator": "cpu"},
+        }
+    )
+    datamodule = cast(Any, SimpleNamespace())
+    module = cast(Any, SimpleNamespace(summary=mocker.Mock(return_value="model-summary")))
+    trainer = cast(Any, SimpleNamespace(fit=mocker.Mock()))
+
+    logger = mocker.patch("ml_sandbox_libs.training.runner.logger")
+    mocker.patch.dict(os.environ, {"RANK": "1"}, clear=False)
+
+    run_training(
+        cfg,
+        prepare_datamodule=lambda _cfg, _save_dir: datamodule,
+        build_module=lambda _cfg, _datamodule: module,
+        build_trainer=lambda _cfg, _save_dir: trainer,
+    )
+
+    module.summary.assert_not_called()
+    trainer.fit.assert_called_once_with(model=module, datamodule=datamodule)
+    logger.info.assert_called_once()

--- a/libs/ml_sandbox_libs/tests/test_training/test_runner.py
+++ b/libs/ml_sandbox_libs/tests/test_training/test_runner.py
@@ -1,0 +1,60 @@
+"""Tests for the shared training runner."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from omegaconf import OmegaConf
+from pytest_mock import MockerFixture
+
+from ml_sandbox_libs.training.runner import run_training
+
+
+def test_run_training_executes_steps_in_order(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Run training in the expected top-level orchestration order."""
+    cfg = OmegaConf.create(
+        {
+            "save_dir": str(tmp_path),
+            "debug": False,
+            "data": {"batch_size": 32},
+            "device": {"accelerator": "cpu"},
+        }
+    )
+    datamodule = SimpleNamespace()
+    module = SimpleNamespace(summary=mocker.Mock(return_value="model-summary"))
+    trainer = SimpleNamespace(fit=mocker.Mock())
+    steps: list[str] = []
+
+    def prepare_datamodule(cfg_arg: Any, save_dir_arg: Path) -> Any:
+        assert cfg_arg is cfg
+        assert save_dir_arg == tmp_path
+        steps.append("prepare_datamodule")
+        return datamodule
+
+    def build_module(cfg_arg: Any, datamodule_arg: Any) -> Any:
+        assert cfg_arg is cfg
+        assert datamodule_arg is datamodule
+        steps.append("build_module")
+        return module
+
+    def build_trainer(cfg_arg: Any, save_dir_arg: Path) -> Any:
+        assert cfg_arg is cfg
+        assert save_dir_arg == tmp_path
+        steps.append("build_trainer")
+        return trainer
+
+    setup_logger = mocker.patch("ml_sandbox_libs.training.runner.setup_logger")
+    set_matmul_precision = mocker.patch("ml_sandbox_libs.training.runner.torch.set_float32_matmul_precision")
+
+    run_training(
+        cfg,
+        prepare_datamodule=prepare_datamodule,
+        build_module=build_module,
+        build_trainer=build_trainer,
+    )
+
+    assert steps == ["prepare_datamodule", "build_module", "build_trainer"]
+    setup_logger.assert_called_once_with()
+    set_matmul_precision.assert_not_called()
+    module.summary.assert_called_once_with(batch_size=cfg.data.batch_size)
+    trainer.fit.assert_called_once_with(model=module, datamodule=datamodule)

--- a/projects/recsys-candidate-generation/src/fit.py
+++ b/projects/recsys-candidate-generation/src/fit.py
@@ -3,12 +3,15 @@ from datetime import datetime
 
 import hydra
 import lightning as L
-import torch
 from lightning.pytorch.callbacks import EarlyStopping
 from lightning.pytorch.loggers import WandbLogger
-from loguru import logger
+from ml_sandbox_libs.data.amazon_reviews_dataset import (
+    AmazonReviewsBipartiteGraphDataModule,
+    AmazonReviewsSeqRecDataModule,
+)
+from ml_sandbox_libs.models.base import BaseModule
 from ml_sandbox_libs.optimizer import create_optimizer
-from ml_sandbox_libs.utils import setup_logger
+from ml_sandbox_libs.training import run_training
 from omegaconf import DictConfig
 
 from const import EVAL_NEG_SAMPLE_SIZE
@@ -53,49 +56,57 @@ def create_trainer(cfg: DictConfig, save_dir: pathlib.Path) -> L.Trainer:
     )
 
 
-@hydra.main(version_base=None, config_path="config", config_name="config")
-def main(cfg: DictConfig) -> None:
-    """Main training function.
+def prepare_datamodule(
+    cfg: DictConfig,
+    save_dir: pathlib.Path,
+) -> AmazonReviewsSeqRecDataModule | AmazonReviewsBipartiteGraphDataModule:
+    """Create the candidate-generation datamodule for the training run.
 
     Args:
-        cfg: Hydra configuration object
+        cfg: Hydra configuration object.
+        save_dir: Base save directory for the experiment.
+
+    Returns:
+        Candidate-generation datamodule instance.
     """
-    setup_logger()
-    logger.info(f"Starting the fit process with configuration: {cfg}")
-
-    if cfg.device.accelerator == "gpu":
-        torch.set_float32_matmul_precision("medium")
-
-    save_dir = pathlib.Path(cfg.save_dir)
-
-    # Initialize data module
-    datamodule = create_datamodule(
+    return create_datamodule(
         cfg=cfg,
         save_dir=save_dir,
         eval_negative_sample_size=EVAL_NEG_SAMPLE_SIZE,
     )
 
-    # Create optimizer
-    optimizer = create_optimizer(cfg)
 
-    # Initialize datamodule metadata required by model factories before module creation.
-    # The bipartite graph datamodule keeps this idempotent, so Lightning can call
-    # prepare_data() again during fit without repeating the expensive preprocessing.
+def build_module(
+    cfg: DictConfig,
+    datamodule: AmazonReviewsSeqRecDataModule | AmazonReviewsBipartiteGraphDataModule,
+) -> BaseModule:
+    """Create the candidate-generation LightningModule.
+
+    Args:
+        cfg: Hydra configuration object.
+        datamodule: Datamodule used for training.
+
+    Returns:
+        Configured candidate-generation LightningModule.
+    """
     datamodule.prepare_data()
+    optimizer = create_optimizer(cfg)
+    return create_model_module(cfg, datamodule, optimizer)
 
-    # Create model
-    module = create_model_module(cfg, datamodule, optimizer)
 
-    # Print model summary
-    logger.info(
-        module.summary(
-            batch_size=cfg.data.batch_size,
-        )
+@hydra.main(version_base=None, config_path="config", config_name="config")
+def main(cfg: DictConfig) -> None:
+    """Main training function.
+
+    Args:
+        cfg: Hydra configuration object.
+    """
+    run_training(
+        cfg,
+        prepare_datamodule=prepare_datamodule,
+        build_module=build_module,
+        build_trainer=create_trainer,
     )
-
-    # Create trainer and start training
-    trainer = create_trainer(cfg, save_dir)
-    trainer.fit(model=module, datamodule=datamodule)
 
 
 if __name__ == "__main__":

--- a/projects/recsys-candidate-generation/src/fit.py
+++ b/projects/recsys-candidate-generation/src/fit.py
@@ -1,5 +1,6 @@
 import pathlib
 from datetime import datetime
+from typing import cast
 
 import hydra
 import lightning as L
@@ -78,7 +79,7 @@ def prepare_datamodule(
 
 def build_module(
     cfg: DictConfig,
-    datamodule: AmazonReviewsSeqRecDataModule | AmazonReviewsBipartiteGraphDataModule,
+    datamodule: L.LightningDataModule,
 ) -> BaseModule:
     """Create the candidate-generation LightningModule.
 
@@ -89,6 +90,10 @@ def build_module(
     Returns:
         Configured candidate-generation LightningModule.
     """
+    datamodule = cast(
+        AmazonReviewsSeqRecDataModule | AmazonReviewsBipartiteGraphDataModule,
+        datamodule,
+    )
     datamodule.prepare_data()
     optimizer = create_optimizer(cfg)
     return create_model_module(cfg, datamodule, optimizer)

--- a/projects/recsys-candidate-generation/src/tests/test_fit.py
+++ b/projects/recsys-candidate-generation/src/tests/test_fit.py
@@ -1,0 +1,29 @@
+"""Tests for candidate-generation fit orchestration helpers."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from omegaconf import OmegaConf
+from pytest_mock import MockerFixture
+
+import fit
+
+
+def test_build_module_prepares_datamodule_before_factory_dispatch(
+    mocker: MockerFixture,
+) -> None:
+    """Prepare the datamodule before model creation reads prepared metadata."""
+    cfg = OmegaConf.create({})
+    datamodule = cast(Any, SimpleNamespace(prepare_data=mocker.Mock()))
+    optimizer = object()
+    module = object()
+
+    create_optimizer = mocker.patch("fit.create_optimizer", return_value=optimizer)
+    create_model_module = mocker.patch("fit.create_model_module", return_value=module)
+
+    result = fit.build_module(cfg, datamodule)
+
+    assert result is module
+    datamodule.prepare_data.assert_called_once_with()
+    create_optimizer.assert_called_once_with(cfg)
+    create_model_module.assert_called_once_with(cfg, datamodule, optimizer)

--- a/projects/recsys-ranking/src/fit.py
+++ b/projects/recsys-ranking/src/fit.py
@@ -3,13 +3,13 @@ from datetime import datetime
 
 import hydra
 import lightning as L
-import torch
 from lightning.pytorch.callbacks import EarlyStopping
 from lightning.pytorch.loggers import WandbLogger
-from loguru import logger
+from ml_sandbox_libs.data.amazon_reviews_dataset import AmazonReviewsSeqRecDataModule
 from ml_sandbox_libs.data.factory import create_seq_rec_datamodule
+from ml_sandbox_libs.models.base import BaseModule
 from ml_sandbox_libs.optimizer import create_optimizer
-from ml_sandbox_libs.utils import setup_logger
+from ml_sandbox_libs.training import run_training
 from omegaconf import DictConfig
 
 from const import EVAL_NEG_SAMPLE_SIZE
@@ -54,23 +54,20 @@ def create_trainer(cfg: DictConfig, save_dir: pathlib.Path) -> L.Trainer:
     )
 
 
-@hydra.main(version_base=None, config_path="config", config_name="config")
-def main(cfg: DictConfig) -> None:
-    """Main training function.
+def prepare_datamodule(
+    cfg: DictConfig,
+    save_dir: pathlib.Path,
+) -> AmazonReviewsSeqRecDataModule:
+    """Create the ranking datamodule for the configured training run.
 
     Args:
-        cfg: Hydra configuration object
+        cfg: Hydra configuration object.
+        save_dir: Base save directory for the experiment.
+
+    Returns:
+        Prepared datamodule instance.
     """
-    setup_logger()
-    logger.info(f"Starting the fit process with configuration: {cfg}")
-
-    if cfg.device.accelerator == "gpu":
-        torch.set_float32_matmul_precision("medium")
-
-    save_dir = pathlib.Path(cfg.save_dir)
-
-    # Initialize data module
-    datamodule = create_seq_rec_datamodule(
+    return create_seq_rec_datamodule(
         save_dir=save_dir,
         batch_size=cfg.data.batch_size,
         max_seq_len=cfg.data.max_seq_len,
@@ -79,29 +76,40 @@ def main(cfg: DictConfig) -> None:
         eval_negative_sample_size=EVAL_NEG_SAMPLE_SIZE,
     )
 
-    # Create optimizer
+
+def build_module(cfg: DictConfig, datamodule: AmazonReviewsSeqRecDataModule) -> BaseModule:
+    """Create the ranking LightningModule for the configured training run.
+
+    Args:
+        cfg: Hydra configuration object.
+        datamodule: Datamodule used for training.
+
+    Returns:
+        Configured ranking LightningModule.
+    """
+    datamodule.prepare_data()
     optimizer = create_optimizer(cfg)
     loss_fn = create_loss(
         cfg,
         num_items=len(datamodule.item2index),
         neg_sample_size=cfg.data.neg_sample_size,
     )
+    return create_model_module(cfg, datamodule, optimizer, loss_fn)
 
-    # Create model
-    module = create_model_module(cfg, datamodule, optimizer, loss_fn)
 
-    # Print model summary
-    logger.info(
-        module.summary(
-            batch_size=cfg.data.batch_size,
-        )
+@hydra.main(version_base=None, config_path="config", config_name="config")
+def main(cfg: DictConfig) -> None:
+    """Main training function.
+
+    Args:
+        cfg: Hydra configuration object.
+    """
+    run_training(
+        cfg,
+        prepare_datamodule=prepare_datamodule,
+        build_module=build_module,
+        build_trainer=create_trainer,
     )
-
-    # Create trainer and start training
-    trainer = create_trainer(cfg, save_dir)
-    logger.info("Starting training...")
-    trainer.fit(model=module, datamodule=datamodule)
-    logger.info("Training completed.")
 
 
 if __name__ == "__main__":

--- a/projects/recsys-ranking/src/fit.py
+++ b/projects/recsys-ranking/src/fit.py
@@ -66,7 +66,8 @@ def prepare_datamodule(
         save_dir: Base save directory for the experiment.
 
     Returns:
-        Prepared datamodule instance.
+        Instantiated datamodule instance; data preparation happens later in
+        ``build_module``.
     """
     return create_seq_rec_datamodule(
         save_dir=save_dir,

--- a/projects/recsys-ranking/src/fit.py
+++ b/projects/recsys-ranking/src/fit.py
@@ -1,5 +1,6 @@
 import pathlib
 from datetime import datetime
+from typing import cast
 
 import hydra
 import lightning as L
@@ -77,7 +78,7 @@ def prepare_datamodule(
     )
 
 
-def build_module(cfg: DictConfig, datamodule: AmazonReviewsSeqRecDataModule) -> BaseModule:
+def build_module(cfg: DictConfig, datamodule: L.LightningDataModule) -> BaseModule:
     """Create the ranking LightningModule for the configured training run.
 
     Args:
@@ -87,6 +88,7 @@ def build_module(cfg: DictConfig, datamodule: AmazonReviewsSeqRecDataModule) -> 
     Returns:
         Configured ranking LightningModule.
     """
+    datamodule = cast(AmazonReviewsSeqRecDataModule, datamodule)
     datamodule.prepare_data()
     optimizer = create_optimizer(cfg)
     loss_fn = create_loss(

--- a/projects/recsys-ranking/src/tests/test_fit.py
+++ b/projects/recsys-ranking/src/tests/test_fit.py
@@ -1,0 +1,43 @@
+"""Tests for ranking fit orchestration helpers."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from omegaconf import OmegaConf
+from pytest_mock import MockerFixture
+
+import fit
+
+
+def test_build_module_prepares_datamodule_before_creating_dependencies(
+    mocker: MockerFixture,
+) -> None:
+    """Prepare the datamodule before reading prepared attributes in factories."""
+    cfg = OmegaConf.create(
+        {
+            "data": {"neg_sample_size": 4},
+        }
+    )
+    datamodule = cast(
+        Any,
+        SimpleNamespace(item2index={"i": 0}, prepare_data=mocker.Mock()),
+    )
+    optimizer = object()
+    loss_fn = object()
+    module = object()
+
+    create_optimizer = mocker.patch("fit.create_optimizer", return_value=optimizer)
+    create_loss = mocker.patch("fit.create_loss", return_value=loss_fn)
+    create_model_module = mocker.patch("fit.create_model_module", return_value=module)
+
+    result = fit.build_module(cfg, datamodule)
+
+    assert result is module
+    datamodule.prepare_data.assert_called_once_with()
+    create_optimizer.assert_called_once_with(cfg)
+    create_loss.assert_called_once_with(
+        cfg,
+        num_items=len(datamodule.item2index),
+        neg_sample_size=cfg.data.neg_sample_size,
+    )
+    create_model_module.assert_called_once_with(cfg, datamodule, optimizer, loss_fn)


### PR DESCRIPTION
## Summary
- extract a shared `run_training` helper for the top-level fit flow in `ml_sandbox_libs.training`
- keep project-specific `create_trainer`, `prepare_datamodule`, and `build_module` helpers in each project `fit.py`
- move datamodule preparation into `build_module` so model construction owns the dependency on prepared datamodule attributes
- add focused tests for the shared runner orchestration and the new `build_module` preparation contract

## Why
- reduce duplicated `fit.py` flow between ranking and candidate-generation without hiding project-specific behavior behind deeper abstractions
- keep code navigation local to each project while centralizing only the straight-line training orchestration

## Validation
- `cd libs/ml_sandbox_libs && make lint`
- `cd libs/ml_sandbox_libs && make test`
- `cd projects/recsys-ranking && make lint`
- `cd projects/recsys-ranking && make test`
- `cd projects/recsys-candidate-generation && make lint`
- `cd projects/recsys-candidate-generation && make test`