### PR TITLE
refactor(recsys): share modules and split metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,6 @@ pyrightconfig.json
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,direnv,python,macos
+
+# Local git worktrees
+.worktrees/

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/models/modules/__init__.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/models/modules/__init__.py
@@ -12,7 +12,9 @@ from ml_sandbox_libs.models.types import (
 from .base import IdEmbedding, LinearBlock, MaskedMeanPooling, PointwiseFeedForward
 from .base.linear_block import build_activation, build_normalization
 from .behavior_encoder import BehaviorEncoder
+from .cross_net import CrossNetV2, CrossNetV2MoE
 from .feature_embedding_dict import FeatureEmbeddingDict
+from .interaction import FactorizationMachine, FirstOrderInteraction, SecondOrderInteraction
 from .mlp import MLP
 from .target_attention import DINAttention
 from .transformer_embedding import TransformerEmbeddings
@@ -22,10 +24,14 @@ __all__ = [
     "MLP",
     "ActivationType",
     "BehaviorEncoder",
+    "CrossNetV2",
+    "CrossNetV2MoE",
     "DINAttention",
+    "FactorizationMachine",
     "FeatureEmbeddingDict",
     "FeatureSpec",
     "FeatureType",
+    "FirstOrderInteraction",
     "IdEmbedding",
     "LinearBlock",
     "LinearOpOrderType",
@@ -33,6 +39,7 @@ __all__ = [
     "MaskedMeanPooling",
     "NormalizeType",
     "PointwiseFeedForward",
+    "SecondOrderInteraction",
     "TransformerEmbeddings",
     "TransformerEncoderBlock",
     "build_activation",

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/models/modules/cross_net.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/models/modules/cross_net.py
@@ -16,8 +16,10 @@ from typing import Any, cast
 
 import torch
 import torch.nn as nn
-from ml_sandbox_libs.models.modules.base import build_activation, build_normalization
+
 from ml_sandbox_libs.models.types import ActivationType, NormalizeType
+
+from .base import build_activation, build_normalization
 
 
 def _build_cross_activation(

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/models/modules/feature_embedding_dict.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/models/modules/feature_embedding_dict.py
@@ -7,20 +7,29 @@ from ml_sandbox_libs.models.base import FeatureSpec, FeatureType
 
 
 class FeatureEmbeddingDict(nn.Module):
-    """Feature embedding dictionary for heterogeneous feature inputs.
+    """Builds per-feature encoders from ``FeatureSpec`` definitions.
 
-    This module creates encoders for:
-    - categorical features
-    - categorical sequence features
-    - continuous features
-
-    Features can share an encoder by specifying the same ``group_key``.
+    Supports categorical, categorical-sequence, and continuous features.
+    Encoders for different features can share weights when their
+    ``FeatureSpec.group_key`` values are identical.
     """
 
     def __init__(self, feature_map: dict[str, FeatureSpec]):
+        """Initialize encoders for every feature in ``feature_map``.
+
+        Args:
+            feature_map: Mapping from feature name to its specification.
+                Each ``FeatureSpec`` drives encoder type, dimensions, and
+                optional encoder sharing via ``group_key``.
+        """
         super().__init__()
+        # Mapping from feature name to its specification.
         self.feature_map = feature_map
+        # Mapping from feature name to its encoder module. When ``group_key``
+        # is shared, multiple names point to the same ``nn.Module`` instance.
         self.feature_encoder = nn.ModuleDict()
+        # Maps a ``group_key`` to the canonical feature name that owns the
+        # shared encoder. Used to look up the existing encoder for reuse.
         self._group_key_dict: dict[str, str] = {}
 
         for feature_name, feature_spec in self.feature_map.items():
@@ -42,11 +51,25 @@ class FeatureEmbeddingDict(nn.Module):
 
     @property
     def output_dims(self) -> int:
-        """Return total output dimensions across all features."""
+        """Total output dimension when all feature embeddings are concatenated.
+
+        Returns:
+            Sum of ``embedding_dims`` across every ``FeatureSpec``.
+        """
         return sum(feature_spec.embedding_dims for feature_spec in self.feature_map.values())
 
     def _validate_shared_feature_map(self, feature_spec: FeatureSpec) -> None:
-        """Validate a feature spec that shares its encoder via ``group_key``."""
+        """Validate compatibility of a feature that re-uses a shared encoder.
+
+        Args:
+            feature_spec: Specification for the feature joining an existing
+                encoder group.
+
+        Raises:
+            ValueError: If ``group_key`` is missing, the existing encoder type
+                is unrecognized, or ``embedding_dims`` does not match the
+                existing encoder's output size.
+        """
         if feature_spec.group_key is None:
             raise ValueError("feature_spec.group_key must be specified for shared features")
 
@@ -65,7 +88,20 @@ class FeatureEmbeddingDict(nn.Module):
             )
 
     def _create_encoder(self, feature_name: str, feature_spec: FeatureSpec) -> nn.Module:
-        """Create an encoder from the feature specification."""
+        """Create an encoder module for a single feature.
+
+        Args:
+            feature_name: Human-readable name used in error messages.
+            feature_spec: Specification that determines encoder type and size.
+
+        Returns:
+            An ``nn.Embedding`` for categorical features or an ``nn.Linear``
+            for continuous features.
+
+        Raises:
+            ValueError: If ``num_ids`` is missing for a categorical feature or
+                the feature type is unrecognized.
+        """
         match feature_spec.type_:
             case FeatureType.CATEGORICAL | FeatureType.CATEGORICAL_SEQUENCE:
                 if feature_spec.num_ids is None:
@@ -83,7 +119,19 @@ class FeatureEmbeddingDict(nn.Module):
                 raise ValueError(f"Unknown feature type: {feature_spec.type_}")
 
     def forward(self, inputs: dict[str, torch.Tensor]) -> OrderedDict[str, torch.Tensor]:
-        """Encode each feature in ``inputs`` and return an ordered embedding dict."""
+        """Encode each feature tensor and return an ordered embedding dict.
+
+        Args:
+            inputs: Mapping from feature name to raw input tensor. Expected
+                dimensions are ``(batch,)`` for categorical and continuous
+                features and ``(batch, seq_len)`` for categorical sequences.
+
+        Returns:
+            Ordered mapping from feature name to its encoded representation.
+
+        Raises:
+            ValueError: If a feature has an unrecognized ``FeatureType``.
+        """
         outputs: OrderedDict[str, torch.Tensor] = OrderedDict()
 
         for feature_name, x in inputs.items():

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/models/modules/interaction.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/models/modules/interaction.py
@@ -1,9 +1,11 @@
 from typing import Literal
 
 import torch
-from ml_sandbox_libs.models.modules import FeatureEmbeddingDict
-from ml_sandbox_libs.models.types import FeatureSpec
 from torch import nn
+
+from ml_sandbox_libs.models.types import FeatureSpec
+
+from .feature_embedding_dict import FeatureEmbeddingDict
 
 
 class FirstOrderInteraction(nn.Module):

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/utils/metrics/__init__.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/utils/metrics/__init__.py
@@ -1,0 +1,32 @@
+"""Compatibility exports for metric utilities.
+
+New code may import from the focused modules directly:
+- `ml_sandbox_libs.utils.metrics.inputs`
+- `ml_sandbox_libs.utils.metrics.retrieval`
+- `ml_sandbox_libs.utils.metrics.formatting`
+"""
+
+from .formatting import format_metrics_dict
+from .inputs import create_classification_inputs, create_retrieval_inputs
+from .retrieval import (
+    MRR,
+    NDCG,
+    HitRate,
+    RetrievalMetrics,
+    hit_rate,
+    mrr,
+    ndcg,
+)
+
+__all__ = [
+    "HitRate",
+    "MRR",
+    "NDCG",
+    "RetrievalMetrics",
+    "create_classification_inputs",
+    "create_retrieval_inputs",
+    "format_metrics_dict",
+    "hit_rate",
+    "mrr",
+    "ndcg",
+]

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/utils/metrics/__init__.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/utils/metrics/__init__.py
@@ -19,9 +19,9 @@ from .retrieval import (
 )
 
 __all__ = [
-    "HitRate",
     "MRR",
     "NDCG",
+    "HitRate",
     "RetrievalMetrics",
     "create_classification_inputs",
     "create_retrieval_inputs",

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/utils/metrics/formatting.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/utils/metrics/formatting.py
@@ -1,0 +1,23 @@
+import torch
+from torchmetrics import Metric
+
+
+def format_metrics_dict(metrics_dict: dict[str, float | torch.Tensor | Metric]) -> str:
+    """Format a metric dictionary as a compact string.
+
+    Args:
+        metrics_dict: Dictionary mapping metric names to scalar values, tensors, or Metric objects.
+
+    Returns:
+        formatted string
+    """
+    formatted_metrics: list[str] = []
+    for key, value in metrics_dict.items():
+        if isinstance(value, Metric):
+            scalar_value: float | torch.Tensor = value.compute()
+        else:
+            scalar_value = value
+        if isinstance(scalar_value, torch.Tensor):
+            scalar_value = scalar_value.item()
+        formatted_metrics.append(f"{key}: {float(scalar_value):.4f}")
+    return " ".join(formatted_metrics)

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/utils/metrics/inputs.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/utils/metrics/inputs.py
@@ -36,5 +36,5 @@ def create_retrieval_inputs(
     score = torch.cat([positive, negative], dim=1)
     target = torch.cat([torch.ones_like(positive), torch.zeros_like(negative)], dim=1).long()
     batch_size, num_samples = score.size()
-    indexes = torch.arange(batch_size, device=score.device).reshape(batch_size, 1).expand(batch_size, num_samples).long()
+    indexes = torch.arange(batch_size, device=score.device).unsqueeze(1).expand(batch_size, num_samples)
     return score, target, indexes

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/utils/metrics/inputs.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/utils/metrics/inputs.py
@@ -36,5 +36,5 @@ def create_retrieval_inputs(
     score = torch.cat([positive, negative], dim=1)
     target = torch.cat([torch.ones_like(positive), torch.zeros_like(negative)], dim=1).long()
     batch_size, num_samples = score.size()
-    indexes = torch.arange(batch_size).reshape(batch_size, 1).expand(batch_size, num_samples).long()
+    indexes = torch.arange(batch_size, device=score.device).reshape(batch_size, 1).expand(batch_size, num_samples).long()
     return score, target, indexes

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/utils/metrics/inputs.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/utils/metrics/inputs.py
@@ -1,0 +1,40 @@
+import torch
+
+
+def create_classification_inputs(
+    positive: torch.Tensor, negative: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build inputs for binary classification.
+
+    Args:
+        positive: positive logits, shape (batch_size, pos_sample_size)
+        negative: negative logits, shape (batch_size, neg_sample_size)
+
+    Returns:
+        logits: logits, shape (batch_size, pos_sample_size + neg_sample_size)
+        labels: labels, shape (batch_size, pos_sample_size + neg_sample_size)
+    """
+    logits = torch.cat([positive, negative], dim=1)
+    labels = torch.cat([torch.ones_like(positive), torch.zeros_like(negative)], dim=1).float()
+    return logits, labels
+
+
+def create_retrieval_inputs(
+    positive: torch.Tensor, negative: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build inputs for retrieval task.
+
+    Args:
+        positive: positive logits, shape (batch_size, pos_sample_size)
+        negative: negative logits, shape (batch_size, neg_sample_size)
+
+    Returns:
+        score: logits, shape (batch_size, pos_sample_size + neg_sample_size)
+        target: target long, shape (batch_size, pos_sample_size + neg_sample_size)
+        indexes: indexes, shape (batch_size, pos_sample_size + neg_sample_size)
+    """
+    score = torch.cat([positive, negative], dim=1)
+    target = torch.cat([torch.ones_like(positive), torch.zeros_like(negative)], dim=1).long()
+    batch_size, num_samples = score.size()
+    indexes = torch.arange(batch_size).reshape(batch_size, 1).expand(batch_size, num_samples).long()
+    return score, target, indexes

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/utils/metrics/retrieval.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/utils/metrics/retrieval.py
@@ -5,45 +5,6 @@ from torch import nn
 from torchmetrics import Metric
 
 
-def create_classification_inputs(
-    positive: torch.Tensor, negative: torch.Tensor
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """build inputs for binary classification
-
-    Args:
-        positive: positive logits, shape (batch_size, pos_sample_size)
-        negative: negative logits, shape (batch_size, neg_sample_size)
-
-    Returns:
-        logits: logits, shape (batch_size, pos_sample_size + neg_sample_size)
-        labels: labels, shape (batch_size, pos_sample_size + neg_sample_size)
-    """
-    logits = torch.cat([positive, negative], dim=1)
-    labels = torch.cat([torch.ones_like(positive), torch.zeros_like(negative)], dim=1).float()
-    return logits, labels
-
-
-def create_retrieval_inputs(
-    positive: torch.Tensor, negative: torch.Tensor
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """build inputs for retrieval task
-
-    Args:
-        pos_logits: positive logits, shape (batch_size, pos_sample_size)
-        neg_logits: negative logits, shape (batch_size, neg_sample_size)
-
-    Returns:
-        score: logits, shape (batch_size, pos_sample_size + neg_sample_size)
-        target: target long, shape (batch_size, pos_sample_size + neg_sample_size)
-        indexes: indexes, shape (batch_size, pos_sample_size + neg_sample_size)
-    """
-    score = torch.cat([positive, negative], dim=1)
-    target = torch.cat([torch.ones_like(positive), torch.zeros_like(negative)], dim=1).long()
-    batch_size, num_samples = score.size()
-    indexes = torch.arange(batch_size).reshape(batch_size, 1).expand(batch_size, num_samples).long()
-    return score, target, indexes
-
-
 def mrr(
     score: torch.Tensor,
     target: torch.Tensor,
@@ -382,24 +343,3 @@ class RetrievalMetrics(nn.Module):
             "mrr": self.mrr,
             "ndcg": self.ndcg,
         }
-
-
-def format_metrics_dict(metrics_dict: dict[str, float | torch.Tensor | Metric]) -> str:
-    """format metrics dict to string
-
-    Args:
-        metrics_dict: metrics dict
-
-    Returns:
-        formatted string
-    """
-    formatted_metrics: list[str] = []
-    for key, value in metrics_dict.items():
-        if isinstance(value, Metric):
-            scalar_value: float | torch.Tensor = value.compute()
-        else:
-            scalar_value = value
-        if isinstance(scalar_value, torch.Tensor):
-            scalar_value = scalar_value.item()
-        formatted_metrics.append(f"{key}: {float(scalar_value):.4f}")
-    return " ".join(formatted_metrics)

--- a/libs/ml_sandbox_libs/tests/test_models/test_modules/test_cross_net.py
+++ b/libs/ml_sandbox_libs/tests/test_models/test_modules/test_cross_net.py
@@ -2,15 +2,11 @@
 
 import pytest
 import torch
-from ml_sandbox_libs.models.modules.base.activation import Dice
-from ml_sandbox_libs.models.types import ActivationType
 
-from models.modules.cross_net import (
-    CrossNetV2,
-    CrossNetV2MoE,
-    _CrossLayerV2,
-    _CrossLayerV2MoE,
-)
+from ml_sandbox_libs.models.modules import CrossNetV2, CrossNetV2MoE
+from ml_sandbox_libs.models.modules.base.activation import Dice
+from ml_sandbox_libs.models.modules.cross_net import _CrossLayerV2, _CrossLayerV2MoE
+from ml_sandbox_libs.models.types import ActivationType
 
 
 class TestCrossLayerV2:

--- a/libs/ml_sandbox_libs/tests/test_models/test_modules/test_interaction.py
+++ b/libs/ml_sandbox_libs/tests/test_models/test_modules/test_interaction.py
@@ -2,13 +2,13 @@
 
 import pytest
 import torch
-from ml_sandbox_libs.models.types import FeatureSpec, FeatureType
 
-from models.modules.interaction import (
+from ml_sandbox_libs.models.modules import (
     FactorizationMachine,
     FirstOrderInteraction,
     SecondOrderInteraction,
 )
+from ml_sandbox_libs.models.types import FeatureSpec, FeatureType
 
 
 class TestFirstOrderInteraction:

--- a/libs/ml_sandbox_libs/tests/test_utils/test_metrics.py
+++ b/libs/ml_sandbox_libs/tests/test_utils/test_metrics.py
@@ -416,3 +416,17 @@ def test_retrieval_metrics() -> None:
     torch.testing.assert_close(metrics.hit_rate.compute(), expected_hr)
     torch.testing.assert_close(metrics.mrr.compute(), expected_mrr)
     torch.testing.assert_close(metrics.ndcg.compute(), expected_ndcg)
+
+
+def test_metric_import_paths_remain_compatible() -> None:
+    """Exports metric utilities from compatibility and focused module paths."""
+    from ml_sandbox_libs.utils.metrics import create_retrieval_inputs as compat_inputs
+    from ml_sandbox_libs.utils.metrics import format_metrics_dict as compat_formatting
+    from ml_sandbox_libs.utils.metrics import mrr as compat_mrr
+    from ml_sandbox_libs.utils.metrics.formatting import format_metrics_dict as focused_formatting
+    from ml_sandbox_libs.utils.metrics.inputs import create_retrieval_inputs as focused_inputs
+    from ml_sandbox_libs.utils.metrics.retrieval import mrr as focused_mrr
+
+    assert compat_inputs is focused_inputs
+    assert compat_formatting is focused_formatting
+    assert compat_mrr is focused_mrr

--- a/libs/ml_sandbox_libs/tests/test_utils/test_metrics.py
+++ b/libs/ml_sandbox_libs/tests/test_utils/test_metrics.py
@@ -40,6 +40,7 @@ def test_create_retrieval_inputs() -> None:
     torch.testing.assert_close(actual_logits, expected_logits)
     torch.testing.assert_close(actual_target, excepted_target)
     torch.testing.assert_close(actual_indexes, expected_indexes)
+    assert actual_indexes.device == actual_logits.device
 
 
 def test_mrr() -> None:

--- a/projects/recsys-candidate-generation/src/models/factory.py
+++ b/projects/recsys-candidate-generation/src/models/factory.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 from ml_sandbox_libs.data.amazon_reviews_dataset import (
     AmazonReviewsBipartiteGraphDataModule,
     AmazonReviewsSeqRecDataModule,
@@ -13,6 +11,58 @@ from omegaconf import DictConfig
 from config.validation import validate_lightgcn_neighbor_config
 from loss import create_embedding_loss, create_score_loss
 from models import LightGCNModule, SASRecModule, SimpleXModule, TwoTowerModule, gSASRecModule
+
+
+def _activation(value: str | None) -> ActivationType | None:
+    """Resolve a model config activation string to an activation enum."""
+    return enum_from_str(ActivationType, value)
+
+
+def _normalize(value: str | None) -> NormalizeType | None:
+    """Resolve a model config normalization string to a normalization enum."""
+    return enum_from_str(NormalizeType, value)
+
+
+def _require_seq_rec_datamodule(
+    datamodule: AmazonReviewsSeqRecDataModule | AmazonReviewsBipartiteGraphDataModule,
+    model_name: str,
+) -> AmazonReviewsSeqRecDataModule:
+    """Return a sequential recommendation datamodule or raise a clear type error.
+
+    Args:
+        datamodule: Datamodule selected by the project data factory.
+        model_name: Model name being constructed.
+
+    Returns:
+        Sequential recommendation datamodule.
+
+    Raises:
+        TypeError: If the selected datamodule is not compatible with the model.
+    """
+    if not isinstance(datamodule, AmazonReviewsSeqRecDataModule):
+        raise TypeError(f"{model_name} requires AmazonReviewsSeqRecDataModule")
+    return datamodule
+
+
+def _require_bipartite_graph_datamodule(
+    datamodule: AmazonReviewsSeqRecDataModule | AmazonReviewsBipartiteGraphDataModule,
+    model_name: str,
+) -> AmazonReviewsBipartiteGraphDataModule:
+    """Return a bipartite graph datamodule or raise a clear type error.
+
+    Args:
+        datamodule: Datamodule selected by the project data factory.
+        model_name: Model name being constructed.
+
+    Returns:
+        Bipartite graph datamodule.
+
+    Raises:
+        TypeError: If the selected datamodule is not compatible with the model.
+    """
+    if not isinstance(datamodule, AmazonReviewsBipartiteGraphDataModule):
+        raise TypeError(f"{model_name} requires AmazonReviewsBipartiteGraphDataModule")
+    return datamodule
 
 
 def create_two_tower_module(
@@ -42,8 +92,8 @@ def create_two_tower_module(
         user_id_dim=cfg.model.user_id_dim,
         item_id_dim=cfg.model.item_id_dim,
         hidden_dims=cfg.model.hidden_dims,
-        normalize=enum_from_str(NormalizeType, cfg.model.normalization),
-        activation=enum_from_str(ActivationType, cfg.model.activation),
+        normalize=_normalize(cfg.model.normalization),
+        activation=_activation(cfg.model.activation),
         dropout=cfg.model.dropout,
         pad_idx=datamodule.item_pad_idx,
         optimizer=optimizer,
@@ -148,8 +198,8 @@ def create_simplex_module(
         item_id_dim=cfg.model.item_id_dim,
         hidden_dims=cfg.model.hidden_dims,
         user_id_weight=cfg.model.user_id_weight,
-        normalize=enum_from_str(NormalizeType, cfg.model.normalization),
-        activation=enum_from_str(ActivationType, cfg.model.activation),
+        normalize=_normalize(cfg.model.normalization),
+        activation=_activation(cfg.model.activation),
         dropout=cfg.model.dropout,
         user_history_pooling=cfg.model.user_history_pooling,
         pad_idx=datamodule.item_pad_idx,
@@ -207,35 +257,22 @@ def create_model_module(
     """
     match cfg.model.name:
         case "TwoTower":
-            return create_two_tower_module(
-                cfg,
-                cast(AmazonReviewsSeqRecDataModule, datamodule),
-                optimizer,
-            )
+            seq_rec_datamodule = _require_seq_rec_datamodule(datamodule, model_name="TwoTower")
+            return create_two_tower_module(cfg, seq_rec_datamodule, optimizer)
         case "SASRec":
-            return create_sasrec_module(
-                cfg,
-                cast(AmazonReviewsSeqRecDataModule, datamodule),
-                optimizer,
-            )
+            seq_rec_datamodule = _require_seq_rec_datamodule(datamodule, model_name="SASRec")
+            return create_sasrec_module(cfg, seq_rec_datamodule, optimizer)
         case "gSASRec":
-            return create_gsasrec_module(
-                cfg,
-                cast(AmazonReviewsSeqRecDataModule, datamodule),
-                optimizer,
-            )
+            seq_rec_datamodule = _require_seq_rec_datamodule(datamodule, model_name="gSASRec")
+            return create_gsasrec_module(cfg, seq_rec_datamodule, optimizer)
         case "SimpleX":
-            return create_simplex_module(
-                cfg,
-                cast(AmazonReviewsSeqRecDataModule, datamodule),
-                optimizer,
-            )
+            seq_rec_datamodule = _require_seq_rec_datamodule(datamodule, model_name="SimpleX")
+            return create_simplex_module(cfg, seq_rec_datamodule, optimizer)
         case "LightGCN":
-            return create_lightgcn_module(
-                cfg,
-                cast(AmazonReviewsBipartiteGraphDataModule, datamodule),
-                optimizer,
+            bipartite_datamodule = _require_bipartite_graph_datamodule(
+                datamodule, model_name="LightGCN"
             )
+            return create_lightgcn_module(cfg, bipartite_datamodule, optimizer)
         case _:
             raise NotImplementedError(
                 f"Model '{cfg.model.name}' is not supported. "

--- a/projects/recsys-candidate-generation/src/tests/test_models/test_factory.py
+++ b/projects/recsys-candidate-generation/src/tests/test_models/test_factory.py
@@ -37,6 +37,8 @@ def test_create_model_module_dispatches_to_matching_creator(
         return sentinel
 
     monkeypatch.setattr(factory, creator_name, fake_creator)
+    monkeypatch.setattr(factory, "_require_seq_rec_datamodule", lambda dm, **_: dm)
+    monkeypatch.setattr(factory, "_require_bipartite_graph_datamodule", lambda dm, **_: dm)
 
     assert factory.create_model_module(cfg, datamodule, optimizer) is sentinel
 
@@ -221,3 +223,47 @@ def test_create_lightgcn_module_uses_embedding_loss_factory_with_bpr(
     assert captured_kwargs["num_layers"] == cfg.model.num_layers
     assert captured_kwargs["eval_top_k"] == cfg.data.eval_top_k
     assert captured_kwargs["optimizer"] is optimizer
+
+
+def test_create_model_module_rejects_bipartite_datamodule_for_seq_rec_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rejects graph datamodules for sequential candidate-generation models."""
+
+    class FakeSeqRecDataModule:
+        pass
+
+    class FakeGraphDataModule:
+        pass
+
+    monkeypatch.setattr(factory, "AmazonReviewsSeqRecDataModule", FakeSeqRecDataModule)
+    monkeypatch.setattr(factory, "AmazonReviewsBipartiteGraphDataModule", FakeGraphDataModule)
+
+    cfg = OmegaConf.create({"model": {"name": "TwoTower"}})
+    datamodule = FakeGraphDataModule()
+    optimizer = cast(Any, SimpleNamespace())
+
+    with pytest.raises(TypeError, match="TwoTower requires AmazonReviewsSeqRecDataModule"):
+        factory.create_model_module(cfg, cast(Any, datamodule), optimizer)
+
+
+def test_create_model_module_rejects_seq_rec_datamodule_for_lightgcn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rejects sequential datamodules for LightGCN."""
+
+    class FakeSeqRecDataModule:
+        pass
+
+    class FakeGraphDataModule:
+        pass
+
+    monkeypatch.setattr(factory, "AmazonReviewsSeqRecDataModule", FakeSeqRecDataModule)
+    monkeypatch.setattr(factory, "AmazonReviewsBipartiteGraphDataModule", FakeGraphDataModule)
+
+    cfg = OmegaConf.create({"model": {"name": "LightGCN"}})
+    datamodule = FakeSeqRecDataModule()
+    optimizer = cast(Any, SimpleNamespace())
+
+    with pytest.raises(TypeError, match="LightGCN requires AmazonReviewsBipartiteGraphDataModule"):
+        factory.create_model_module(cfg, cast(Any, datamodule), optimizer)

--- a/projects/recsys-ranking/src/fit.py
+++ b/projects/recsys-ranking/src/fit.py
@@ -14,7 +14,7 @@ from ml_sandbox_libs.training import run_training
 from omegaconf import DictConfig
 
 from const import EVAL_NEG_SAMPLE_SIZE
-from loss import create_loss
+from loss import create_score_loss
 from models.factory import create_model_module
 
 
@@ -92,7 +92,7 @@ def build_module(cfg: DictConfig, datamodule: L.LightningDataModule) -> BaseModu
     datamodule = cast(AmazonReviewsSeqRecDataModule, datamodule)
     datamodule.prepare_data()
     optimizer = create_optimizer(cfg)
-    loss_fn = create_loss(
+    loss_fn = create_score_loss(
         cfg,
         num_items=len(datamodule.item2index),
         neg_sample_size=cfg.data.neg_sample_size,

--- a/projects/recsys-ranking/src/loss/__init__.py
+++ b/projects/recsys-ranking/src/loss/__init__.py
@@ -1,3 +1,3 @@
-from .factory import create_loss
+from .factory import create_score_loss
 
-__all__ = ["create_loss"]
+__all__ = ["create_score_loss"]

--- a/projects/recsys-ranking/src/loss/factory.py
+++ b/projects/recsys-ranking/src/loss/factory.py
@@ -2,8 +2,8 @@ from ml_sandbox_libs.loss import BCE, ScoreLossFn, gBCE
 from omegaconf import DictConfig
 
 
-def create_loss(cfg: DictConfig, num_items: int, neg_sample_size: int) -> ScoreLossFn:
-    """Create loss function from configuration.
+def create_score_loss(cfg: DictConfig, *, num_items: int, neg_sample_size: int) -> ScoreLossFn:
+    """Create a score-based loss for ranking models.
 
     Args:
         cfg: Configuration dictionary (cfg.loss)

--- a/projects/recsys-ranking/src/loss/factory.py
+++ b/projects/recsys-ranking/src/loss/factory.py
@@ -6,7 +6,7 @@ def create_score_loss(cfg: DictConfig, *, num_items: int, neg_sample_size: int) 
     """Create a score-based loss for ranking models.
 
     Args:
-        cfg: Configuration dictionary (cfg.loss)
+        cfg: Full Hydra configuration object with a ``loss`` section.
         num_items: Number of items (required for gBCE)
         neg_sample_size: Negative sample size (required for gBCE)
 

--- a/projects/recsys-ranking/src/models/dcnv2.py
+++ b/projects/recsys-ranking/src/models/dcnv2.py
@@ -18,7 +18,13 @@ from lightning.pytorch.utilities.types import OptimizerLRSchedulerConfig
 from ml_sandbox_libs.data.amazon_reviews_dataset import AmazonReviewsSeqRecBatch
 from ml_sandbox_libs.loss import ScoreLossFn
 from ml_sandbox_libs.models.base import BaseModule
-from ml_sandbox_libs.models.modules import MLP, BehaviorEncoder, FeatureEmbeddingDict
+from ml_sandbox_libs.models.modules import (
+    MLP,
+    BehaviorEncoder,
+    CrossNetV2,
+    CrossNetV2MoE,
+    FeatureEmbeddingDict,
+)
 from ml_sandbox_libs.models.types import ActivationType, FeatureSpec, FeatureType, NormalizeType
 from ml_sandbox_libs.optimizer import Optimizer
 from ml_sandbox_libs.training import ExperimentMonitor, summarize_pos_neg_scores
@@ -33,7 +39,6 @@ from torchinfo import ModelStatistics, summary
 from torchmetrics.classification import BinaryAccuracy
 
 from .base import RankingModelBase
-from .modules.cross_net import CrossNetV2, CrossNetV2MoE
 
 
 class DCNv2(RankingModelBase):

--- a/projects/recsys-ranking/src/models/deepfm.py
+++ b/projects/recsys-ranking/src/models/deepfm.py
@@ -6,7 +6,7 @@ from lightning.pytorch.utilities.types import OptimizerLRSchedulerConfig
 from ml_sandbox_libs.data.amazon_reviews_dataset import AmazonReviewsSeqRecBatch
 from ml_sandbox_libs.loss import ScoreLossFn
 from ml_sandbox_libs.models.base import BaseModule
-from ml_sandbox_libs.models.modules import MLP, FeatureEmbeddingDict
+from ml_sandbox_libs.models.modules import MLP, FactorizationMachine, FeatureEmbeddingDict
 from ml_sandbox_libs.models.types import ActivationType, FeatureSpec, FeatureType, NormalizeType
 from ml_sandbox_libs.optimizer import Optimizer
 from ml_sandbox_libs.training import ExperimentMonitor, summarize_pos_neg_scores
@@ -20,7 +20,6 @@ from torchinfo import ModelStatistics, summary
 from torchmetrics.classification import BinaryAccuracy
 
 from .base import RankingModelBase
-from .modules.interaction import FactorizationMachine
 
 
 class DeepFM(RankingModelBase):

--- a/projects/recsys-ranking/src/models/dlrm.py
+++ b/projects/recsys-ranking/src/models/dlrm.py
@@ -6,7 +6,12 @@ from lightning.pytorch.utilities.types import OptimizerLRSchedulerConfig
 from ml_sandbox_libs.data.amazon_reviews_dataset import AmazonReviewsSeqRecBatch
 from ml_sandbox_libs.loss import ScoreLossFn
 from ml_sandbox_libs.models.base import BaseModule
-from ml_sandbox_libs.models.modules import MLP, BehaviorEncoder, FeatureEmbeddingDict
+from ml_sandbox_libs.models.modules import (
+    MLP,
+    BehaviorEncoder,
+    FeatureEmbeddingDict,
+    SecondOrderInteraction,
+)
 from ml_sandbox_libs.models.types import ActivationType, FeatureSpec, FeatureType, NormalizeType
 from ml_sandbox_libs.optimizer import Optimizer
 from ml_sandbox_libs.training import ExperimentMonitor, summarize_pos_neg_scores
@@ -20,7 +25,6 @@ from torchinfo import ModelStatistics, summary
 from torchmetrics.classification import BinaryAccuracy
 
 from .base import RankingModelBase
-from .modules.interaction import SecondOrderInteraction
 
 
 class DLRM(RankingModelBase):

--- a/projects/recsys-ranking/src/models/factory.py
+++ b/projects/recsys-ranking/src/models/factory.py
@@ -13,6 +13,16 @@ from .din import DINModule
 from .dlrm import DLRMModule
 
 
+def _activation(value: str | None) -> ActivationType | None:
+    """Resolve a model config activation string to an activation enum."""
+    return enum_from_str(ActivationType, value)
+
+
+def _normalize(value: str | None) -> NormalizeType | None:
+    """Resolve a model config normalization string to a normalization enum."""
+    return enum_from_str(NormalizeType, value)
+
+
 def create_dlrm(
     cfg: DictConfig,
     datamodule: AmazonReviewsSeqRecDataModule,
@@ -42,15 +52,15 @@ def create_dlrm(
         loss_fn=loss_fn,
         behavior_encoder_type=cfg.model.behavior_encoder_type,
         behavior_din_hidden_dims=cfg.model.behavior_din_hidden_dims,
-        behavior_din_activation=enum_from_str(ActivationType, cfg.model.behavior_din_activation),
-        behavior_din_normalize=enum_from_str(NormalizeType, cfg.model.behavior_din_normalize),
+        behavior_din_activation=_activation(cfg.model.behavior_din_activation),
+        behavior_din_normalize=_normalize(cfg.model.behavior_din_normalize),
         behavior_din_dropout=cfg.model.behavior_din_dropout,
         behavior_din_use_softmax=cfg.model.behavior_din_use_softmax,
-        dense_activation=enum_from_str(ActivationType, cfg.model.dense_activation),
-        dense_normalize=enum_from_str(NormalizeType, cfg.model.dense_normalize),
+        dense_activation=_activation(cfg.model.dense_activation),
+        dense_normalize=_normalize(cfg.model.dense_normalize),
         dense_dropout=cfg.model.dense_dropout,
-        top_activation=enum_from_str(ActivationType, cfg.model.top_activation),
-        top_normalize=enum_from_str(NormalizeType, cfg.model.top_normalize),
+        top_activation=_activation(cfg.model.top_activation),
+        top_normalize=_normalize(cfg.model.top_normalize),
         top_dropout=cfg.model.top_dropout,
     )
 
@@ -84,12 +94,12 @@ def create_din(
         eval_top_k=cfg.data.eval_top_k,
         optimizer=optimizer,
         loss_fn=loss_fn,
-        din_activation=enum_from_str(ActivationType, cfg.model.din_activation),
-        din_normalize=enum_from_str(NormalizeType, cfg.model.din_normalize),
+        din_activation=_activation(cfg.model.din_activation),
+        din_normalize=_normalize(cfg.model.din_normalize),
         din_dropout=cfg.model.din_dropout,
         din_use_softmax=cfg.model.din_use_softmax,
-        dnn_activation=enum_from_str(ActivationType, cfg.model.dnn_activation),
-        dnn_normalize=enum_from_str(NormalizeType, cfg.model.dnn_normalize),
+        dnn_activation=_activation(cfg.model.dnn_activation),
+        dnn_normalize=_normalize(cfg.model.dnn_normalize),
         dnn_dropout=cfg.model.dnn_dropout,
     )
 
@@ -120,8 +130,8 @@ def create_deepfm(
         eval_top_k=cfg.data.eval_top_k,
         optimizer=optimizer,
         loss_fn=loss_fn,
-        deep_activation=enum_from_str(ActivationType, cfg.model.deep_activation),
-        deep_normalize=enum_from_str(NormalizeType, cfg.model.deep_normalize),
+        deep_activation=_activation(cfg.model.deep_activation),
+        deep_normalize=_normalize(cfg.model.deep_normalize),
         deep_dropout=cfg.model.deep_dropout,
     )
 
@@ -156,16 +166,16 @@ def create_dcnv2(
         cross_net_type=cfg.model.cross_net_type,
         behavior_encoder_type=cfg.model.behavior_encoder_type,
         behavior_din_hidden_dims=cfg.model.behavior_din_hidden_dims,
-        behavior_din_activation=enum_from_str(ActivationType, cfg.model.behavior_din_activation),
-        behavior_din_normalize=enum_from_str(NormalizeType, cfg.model.behavior_din_normalize),
+        behavior_din_activation=_activation(cfg.model.behavior_din_activation),
+        behavior_din_normalize=_normalize(cfg.model.behavior_din_normalize),
         behavior_din_dropout=cfg.model.behavior_din_dropout,
         behavior_din_use_softmax=cfg.model.behavior_din_use_softmax,
         num_experts=cfg.model.num_experts,
         cross_rank=cfg.model.cross_rank,
-        cross_activation=enum_from_str(ActivationType, cfg.model.cross_activation),
-        cross_normalize=enum_from_str(NormalizeType, cfg.model.cross_normalize),
-        deep_activation=enum_from_str(ActivationType, cfg.model.deep_activation),
-        deep_normalize=enum_from_str(NormalizeType, cfg.model.deep_normalize),
+        cross_activation=_activation(cfg.model.cross_activation),
+        cross_normalize=_normalize(cfg.model.cross_normalize),
+        deep_activation=_activation(cfg.model.deep_activation),
+        deep_normalize=_normalize(cfg.model.deep_normalize),
         deep_dropout=cfg.model.deep_dropout,
     )
 

--- a/projects/recsys-ranking/src/tests/test_fit.py
+++ b/projects/recsys-ranking/src/tests/test_fit.py
@@ -27,7 +27,7 @@ def test_build_module_prepares_datamodule_before_creating_dependencies(
     module = object()
 
     create_optimizer = mocker.patch("fit.create_optimizer", return_value=optimizer)
-    create_loss = mocker.patch("fit.create_loss", return_value=loss_fn)
+    create_score_loss = mocker.patch("fit.create_score_loss", return_value=loss_fn)
     create_model_module = mocker.patch("fit.create_model_module", return_value=module)
 
     result = fit.build_module(cfg, datamodule)
@@ -35,7 +35,7 @@ def test_build_module_prepares_datamodule_before_creating_dependencies(
     assert result is module
     datamodule.prepare_data.assert_called_once_with()
     create_optimizer.assert_called_once_with(cfg)
-    create_loss.assert_called_once_with(
+    create_score_loss.assert_called_once_with(
         cfg,
         num_items=len(datamodule.item2index),
         neg_sample_size=cfg.data.neg_sample_size,

--- a/projects/recsys-ranking/src/tests/test_loss.py
+++ b/projects/recsys-ranking/src/tests/test_loss.py
@@ -1,5 +1,9 @@
+import pytest
 import torch
 from ml_sandbox_libs.loss import BCE, gBCE
+from omegaconf import OmegaConf
+
+from loss.factory import create_score_loss
 
 
 def test_bce_calc_scores() -> None:
@@ -44,3 +48,29 @@ def test_gbce_forward() -> None:
     assert isinstance(loss, torch.Tensor)
     assert loss.ndim == 0
     assert loss > 0
+
+
+def test_create_score_loss_returns_bce() -> None:
+    """Creates BCE for bce ranking loss config."""
+    cfg = OmegaConf.create({"loss": {"name": "bce"}})
+
+    loss_fn = create_score_loss(cfg, num_items=10, neg_sample_size=3)
+
+    assert isinstance(loss_fn, BCE)
+
+
+def test_create_score_loss_returns_gbce() -> None:
+    """Creates gBCE for gbce ranking loss config."""
+    cfg = OmegaConf.create({"loss": {"name": "gbce", "t": 0.5}})
+
+    loss_fn = create_score_loss(cfg, num_items=10, neg_sample_size=3)
+
+    assert isinstance(loss_fn, gBCE)
+
+
+def test_create_score_loss_rejects_unknown_loss() -> None:
+    """Rejects unsupported ranking score loss config."""
+    cfg = OmegaConf.create({"loss": {"name": "unknown"}})
+
+    with pytest.raises(ValueError, match="Unknown loss function: unknown"):
+        create_score_loss(cfg, num_items=10, neg_sample_size=3)


### PR DESCRIPTION
## Summary
推薦系 project 間で再利用できる model building block と metrics utility を整理し、project 固有の training flow / model composition は各 project 側に残したまま責務境界を明確にします。

## Related Issues
N/A

## 背景・目的
`projects/recsys-ranking` と `projects/recsys-candidate-generation` は、実験・学習コードを project ごとに持ちつつ、再利用可能な部品は `libs/ml_sandbox_libs` に寄せる方針です。

今回、ranking 側に閉じていた feature interaction / DCNv2 cross-net は、dataset や training flow に依存しない汎用 `nn.Module` building block だったため、shared library 側へ移動しました。一方で、LightningModule wrapper や training/validation step は可読性を優先し、共通化していません。

また、`ml_sandbox_libs.utils.metrics` は入力生成・retrieval metrics・formatting が1ファイルに混在していたため、既存 import 互換を維持しながら `utils/metrics/` package に分割しました。

## Changes
- `FactorizationMachine`, `FirstOrderInteraction`, `SecondOrderInteraction`, `CrossNetV2`, `CrossNetV2MoE` を `libs/ml_sandbox_libs.models.modules` に移動し、unit test も libs 側へ移動
- `ml_sandbox_libs.utils.metrics` を `utils/metrics/` package に分割し、既存の `from ml_sandbox_libs.utils.metrics import ...` は re-export で維持
- recsys model factory の enum 解決 helper を追加し、factory の可読性を改善
- candidate-generation の `cast(...)` による datamodule narrowing を runtime check 付き helper に置換
- ranking の loss factory を `create_loss` から `create_score_loss` に rename し、用途を明確化
- project-local に残っていた旧 module/test directory を cleanup

## How to Test
- [x] `cd libs/ml_sandbox_libs && make lint`
- [x] `cd libs/ml_sandbox_libs && uv run pytest tests/test_models/test_modules/test_interaction.py tests/test_models/test_modules/test_cross_net.py tests/test_utils/test_metrics.py -v` (72 passed)
- [x] `cd projects/recsys-ranking && make lint && make test` (96 passed)
- [x] `cd projects/recsys-candidate-generation && make lint && make test` (48 passed)

## Additional Context
`cd libs/ml_sandbox_libs && make test` は、`test_bipartite_graph_transform_preserves_public_indices_for_loader_batches` で `NeighborSampler` が `pyg-lib` または `torch-sparse` を要求するため 1 件失敗します。今回の refactor とは無関係な環境依存 failure と判断しています。