### PR TITLE
fix(recsys): local docker build and wandb authentication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,15 +3,22 @@
 ## 1. System Context
 
 - このリポジトリは、機械学習モデル実装と実験を行うための Python モノレポです。
-- 推薦系の主要 project は `projects/recsys-ranking` と `projects/recsys-candidate-generation` です。
+- 主な project / app は次の通りです。
+    - `projects/recsys-ranking`: 推薦システムの Ranking 段階（DeepFM, DLRM, DIN, DCNv2 など）
+    - `projects/recsys-candidate-generation`: 推薦システムの Candidate Generation 段階（TwoTower, SASRec, gSASRec, SimpleX, LightGCN など）
+    - `projects/sentiment_analysis`: IMDB レビューを用いた Transformer Encoder のフルスクラッチ実装による感情分類。`libs/ml_sandbox_libs` に依存しない独立 project です。
+    - `apps/vertex-job-runner`: Vertex AI Custom Training Job を投入するための CLI（エントリポイント `vrun`）
 - アーキテクチャは「project ごとの実験・学習コード」と「再利用可能な shared library」を分離する前提です。
 - ディレクトリ構成の意味は次の通りです。
     - `apps/`: CLI や実行アプリケーションを置きます。現在は `vertex-job-runner` が該当します。
     - `libs/`: 複数 project で再利用する共通ライブラリを置きます。中心は `libs/ml_sandbox_libs` です。
     - `projects/`: 推薦、分類などの各 ML project を置きます。学習コード、設定、tests を project ごとに持ちます。
     - `infra/`: Terraform などのインフラ定義を置きます。Python package と同じ前提では扱いません。
+    - `make/`: 全 package の Makefile が共通して include する `help.mk`, `python.mk` を置きます。
+    - `docs/`: 設計資料や plan など、ドキュメント類を置きます。Python package ではありません。
 - 共通化できる型、module、utility は `libs/ml_sandbox_libs` に寄せます。
 - project 固有の business logic、training flow、model composition は各 project 配下に残します。
+- monorepo 内の package 間依存は `pyproject.toml` の `[tool.uv.sources]` で local path を editable 指定します。recsys 系 project は `ml-sandbox-libs` と `vertex-job-runner` に依存します。`sentiment_analysis` は独立 project で shared library に依存しません。
 - `libs/ml_sandbox_libs` を変更した場合は、library 単体だけでなく downstream project への影響も確認します。
 - shared module の単体テストは `libs/ml_sandbox_libs/tests` に置き、project 側には integration test を残します。
 - public な使い方、配置、import path を変えた場合は、関連 README も更新対象です。
@@ -19,42 +26,61 @@
 ## 2. Tech Stack & Libraries
 
 - 主言語は Python です。
-- Python は 3.12 系を前提にします。各 package の `pyproject.toml` でも `requires-python` は 3.12 系で揃っています。
-- ツール管理は `mise.toml` と `uv` を前提にします。現状の `uv` 管理バージョンは 0.10.4 です。
-- 多くの Python package は `pyproject.toml` と `Makefile` を持ち、依存管理・lint・test は package 単位で行います。
-- 中心となるライブラリ群は、PyTorch、Lightning、Hydra、Polars、NumPy、TorchMetrics、Loguru です。project により `timm`、`wandb`、`google-cloud-aiplatform` などを使います。
+- Python は 3.12 系を前提にします。各 package の `pyproject.toml` で `requires-python` は 3.12 系で揃っています（`vertex-job-runner` のみ `>=3.12` で上限なし）。
+- ツール管理は `mise.toml` と `uv` を前提にします。`mise.toml` で `uv` と `fd` を管理します。現状の `uv` 管理バージョンは 0.11.6 です。
+- 多くの Python package は `pyproject.toml` と `Makefile` を持ち、依存管理・lint・test は package 単位で行います。各 Makefile は `make/help.mk` と `make/python.mk` を include し、共通の `lint`, `fmt`, `test`, `clean-cache`, `lock` target を提供します。
+- 中心となるライブラリ群は、PyTorch、Lightning、Hydra、Polars、NumPy、TorchMetrics、Loguru、Torch Geometric (PyG)、`datasets`、`tensorboard`、`timm` です。
+- project / app ごとの主な追加ライブラリ:
+    - `recsys-ranking`, `recsys-candidate-generation`: `wandb`、`timm`。PyTorch は `cpu` / `gpu` の optional dependency（extra）で切り替え。`recsys-candidate-generation` は PyG 拡張（`torch_scatter`, `torch_sparse`, `torch_cluster`, `pyg_lib`）も利用。
+    - `sentiment_analysis`: `transformers`、`datasets`、`spacy`、`bertviz`、`rich`、`tensorboard`（PyTorch は `lightning` 経由）。
+    - `vertex-job-runner`: `google-cloud-aiplatform`、`pydantic`、`pydantic-settings`、`typer`。
+    - `ml_sandbox_libs`: `google-cloud-logging`、`torch_geometric` と PyG 拡張。
 - 依存追加は慎重に扱ってください。既存ライブラリで解決できるなら新規 package を増やしません。
 - 新しい Python package を勝手に追加しないでください。追加が必要な場合だけ、理由が明確で影響範囲が分かる状態で対象 package の `pyproject.toml` を最小限更新します。
-- 既存の依存解決や GPU/CPU 切替は `uv` と `pyproject.toml` の設定に従います。個別の install 手順を横に増やさないでください。
+- 既存の依存解決や GPU/CPU 切替は `uv` と `pyproject.toml` の `optional-dependencies`（`cpu` / `gpu` extra）に従います。個別の install 手順を横に増やさないでください。
 - Python の docstring は Google style を使います。`Args:`, `Returns:`, `Raises:` を使い、型注釈がある前提で docstring 内に型を重ねて書く必要はありません。
 
 ## 3. Workflow Commands
 
 - Python 関連の実行は必ず `uv` を通します。`python`, `pip`, `pytest` を直接叩かず、`uv run ...` または各 package の `make` を使ってください。
 - 作業前に、変更対象の package root へ移動してからコマンドを実行してください。
-- 標準ワークフローは次です。
-    - `make install`: 依存関係のセットアップ
-    - `make fmt`: formatter の適用
-    - `make lint`: `ruff` と `mypy` の実行
+- 共通 target（`make/python.mk` 経由で全 package が利用可能）:
+    - `make install`: 依存関係のセットアップ（package 固有の定義による）
+    - `make fmt`: formatter の適用（`ruff check --fix` + `ruff format`）
+    - `make lint`: `ruff check` と `mypy` の実行
     - `make test`: `pytest` の実行
+    - `make lock`: `uv lock` の実行
+    - `make clean-cache`: cache 削除
 - `libs/ml_sandbox_libs` の標準確認:
-    - `cd libs/ml_sandbox_libs && make install`
+    - `cd libs/ml_sandbox_libs && make install`（GPU 有無で `--extra=gpu` / `--extra=cpu` を自動切替）
     - `cd libs/ml_sandbox_libs && make fmt`
     - `cd libs/ml_sandbox_libs && make lint`
     - `cd libs/ml_sandbox_libs && make test`
 - `projects/recsys-ranking` の標準確認:
-    - `cd projects/recsys-ranking && make install`
+    - `cd projects/recsys-ranking && make install`（GPU 有無で `--extra=gpu` / `--extra=cpu` を自動切替）
     - `cd projects/recsys-ranking && make fmt`
     - `cd projects/recsys-ranking && make lint`
     - `cd projects/recsys-ranking && make test`
-    - 学習実行は `cd projects/recsys-ranking && make train` または `uv run python src/fit.py ...`
+    - 学習実行は `uv run python src/fit.py model=DeepFM data.batch_size=32` のように Hydra override を使います。`make train` target は未定義のため `uv run python src/fit.py ...` を直接実行してください。
 - `projects/recsys-candidate-generation` も基本は同じで、package root で `make install`, `make fmt`, `make lint`, `make test` を使います。
+    - 学習実行は `uv run python src/fit.py model=SASRec data.batch_size=64` のように Hydra override を使います。`make train` target は未定義のため `uv run python src/fit.py ...` を直接実行してください。
+    - GPU 環境向けに `Dockerfile` と `compose.yaml` があり、`docker compose` で GPU コンテナを起動できます。
+- `projects/sentiment_analysis` の標準確認:
+    - `cd projects/sentiment_analysis && make install`
+    - `cd projects/sentiment_analysis && make fmt`
+    - `cd projects/sentiment_analysis && make lint`
+    - `cd projects/sentiment_analysis && make test`
+    - 学習実行は `make train`（`uv run python train.py`）。この project は `libs/ml_sandbox_libs` に依存しない独立 project です。
 - `apps/vertex-job-runner` の標準確認:
     - `cd apps/vertex-job-runner && make install`
+    - `cd apps/vertex-job-runner && make fmt`
     - `cd apps/vertex-job-runner && make lint`
     - `cd apps/vertex-job-runner && make test`
     - README ベースで確認する場合も `uv sync`, `uv run pytest` を使います。
 - `infra/terraform` は Python package と切り離して扱い、変更時は Terraform 側の Makefile と構成を確認してから実行します。
+    - `cd infra/terraform && make format`（`terraform fmt -recursive`）
+    - `cd infra/terraform && make lint`（`tflint` + `trivy`）
+- CI: GitHub Actions（`.github/workflows/python-ci.yml`）が `pyproject.toml` + `Makefile` を持つ package を自動検出し、`make install`, `make lint`, `make test` を実行します。PR 時は各 package でこれらが通ることを前提にします。
 - 変更した package では少なくとも `make lint` と `make test` を通します。
 - `libs/ml_sandbox_libs` を変更した場合は、必要に応じて関連 project の test も追加で実行します。
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Python CI](https://github.com/haru-256/ml-sandbox/actions/workflows/python-ci.yml/badge.svg)](https://github.com/haru-256/ml-sandbox/actions/workflows/python-ci.yml)
 
-`ml-sandbox` は、推薦システムを中心に機械学習モデルの実装、実験、基盤整備を進める Python monorepo です。主な対象は `projects/recsys-candidate-generation` と `projects/recsys-ranking` で、候補生成とランキングを別 project として切り出し、その下支えとなる前処理、DataModule、共通 model module、optimizer、学習 utility は `libs/ml_sandbox_libs` に集約しています。実験の実行基盤は `apps/vertex-job-runner` に分離しており、model 実装だけでなく shared library 化とクラウド実行まで含めて設計しています。
+`ml-sandbox` は、推薦システムを中心に機械学習モデルの実装、実験、基盤整備を進める Python monorepo です。推薦系は `projects/recsys-candidate-generation` と `projects/recsys-ranking` で候補生成とランキングを別 project として切り出し、その下支えとなる前処理、DataModule、共通 model module、optimizer、学習 utility は `libs/ml_sandbox_libs` に集約しています。実験の実行基盤は `apps/vertex-job-runner` に分離しており、model 実装だけでなく shared library 化とクラウド実行まで含めて設計しています。推薦系以外に、Transformer Encoder をフルスクラッチで実装する `projects/sentiment_analysis` も独立 project として含んでいます。
 
 技術スタックは Python 3.12 を前提に、`uv` と Makefile で package ごとに開発し、PyTorch、Lightning、Hydra、Polars、NumPy、TorchMetrics、PyTorch Geometric、Google Cloud / Vertex AI を中心に組み立てています。コードベースとしては、project ごとの関心を分けつつ shared component を明確に切り出し、型注釈、`mypy`、`ruff`、`pytest`、GitHub Actions を前提に保守している repo です。
 
@@ -238,6 +238,7 @@ flowchart LR
 
 ここがこのリポジトリの中心です。
 特に推薦システム領域において、検索・候補生成・ランキングという構成に近い問題設定を扱っています。
+推薦系以外にも、Transformer Encoder をフルスクラッチ実装する `projects/sentiment_analysis` を独立 project として含んでいます。
 
 ### Recsys Candidate Generation
 
@@ -373,6 +374,17 @@ Ranking では、candidate generation よりも豊かな特徴量相互作用を
 
 詳細は [`projects/recsys-ranking/README.md`](projects/recsys-ranking/README.md) を参照してください。
 
+### Sentiment Analysis
+
+`projects/sentiment_analysis`
+
+IMDB の映画レビューを用いて、Transformer Encoder をフルスクラッチ実装で学習・評価する project です。
+PyTorch / Lightning ベースで、前処理、語彙構築、データセット実装、Self-Attention、Encoder block、分類ヘッドまでを一通り含んでいます。
+
+`libs/ml_sandbox_libs` に依存しない独立 project で、推薦系 project とは異なり Hydra を使わず `train.py` を直接実行する構成です。
+
+詳細は [`projects/sentiment_analysis/README.md`](projects/sentiment_analysis/README.md) を参照してください。
+
 ## 共通ライブラリ
 
 ### ml_sandbox_libs
@@ -467,6 +479,7 @@ Python 関連コマンドは package root で `uv` 前提の Makefile を使い�
 cd libs/ml_sandbox_libs && make install && make lint && make test
 cd projects/recsys-ranking && make install && make lint && make test
 cd projects/recsys-candidate-generation && make install && make lint && make test
+cd projects/sentiment_analysis && make install && make lint && make test
 cd apps/vertex-job-runner && make install && make lint && make test
 ```
 

--- a/docs/superpowers/plans/2026-07-03-apply-pr159-fixes-to-recsys-ranking.md
+++ b/docs/superpowers/plans/2026-07-03-apply-pr159-fixes-to-recsys-ranking.md
@@ -1,0 +1,545 @@
+# Apply PR159 Fixes to Recsys Ranking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the four PR #159 local Docker/W&B and training-policy fixes from `projects/recsys-candidate-generation` to `projects/recsys-ranking`.
+
+**Architecture:** Keep `projects/recsys-ranking` self-contained and mirror only the candidate-generation patterns that are valid for ranking. Docker support should replicate the monorepo layout inside the image so editable local path dependencies resolve, while `vertex-job-runner` is excluded from the runtime Docker dependency set via a dependency group. Checkpointing should be an explicit Hydra contract, disabled by default and stored under `save_dir/checkpoints` only when enabled.
+
+**Tech Stack:** Python 3.12, uv 0.11.6, Makefile targets, Docker/Compose, Lightning, Hydra, WandB, PyTorch/TorchVision.
+
+## Global Constraints
+
+- Do not commit, push, rebase, reset, or revert unless explicitly asked.
+- Preserve existing user changes, including the current `projects/recsys-candidate-generation/Makefile` diff.
+- Run Python commands from package roots and through `make` / `uv`; do not run direct `python`, `pip`, or `pytest`.
+- Keep changes scoped to `projects/recsys-ranking` unless a lock/update command requires a package-local file update.
+- Follow the candidate-generation policy: checkpointing defaults to off; if enabled, checkpoints are local under `save_dir/checkpoints`.
+- Docker local training should require `WANDB_API_KEY` and should not reintroduce GCS env or mounted-volume plumbing.
+
+---
+
+## File Structure
+
+- Modify `projects/recsys-ranking/pyproject.toml`: move `vertex-job-runner` from project dependencies to `dependency-groups.vertex`; keep the editable source entry; evaluate GPU index alignment with PR #159.
+- Modify `projects/recsys-ranking/uv.lock`: regenerate from ranking package root after dependency changes.
+- Create `projects/recsys-ranking/Dockerfile`: ranking-specific Docker build using the same monorepo layout pattern as candidate-generation.
+- Create `projects/recsys-ranking/compose.yaml`: dev shell service with `additional_contexts`, required `WANDB_API_KEY`, default image name, and GPU reservation.
+- Create `projects/recsys-ranking/.env.example`: local Docker env sample with `WANDB_API_KEY`, `IMAGE_URI`, and `EXPERIMENT_NAME`.
+- Modify `projects/recsys-ranking/.gitignore`: ignore `.env` if not already ignored.
+- Modify `projects/recsys-ranking/Makefile`: add `docker-build`, `docker-run`, `docker-up`, `docker-exec`, and `docker-down` targets.
+- Modify `projects/recsys-ranking/src/config/config.yaml`: add required `enable_checkpointing: false`.
+- Modify `projects/recsys-ranking/src/fit.py`: add opt-in `ModelCheckpoint`, `enable_checkpointing`, and `default_root_dir`.
+- Modify `projects/recsys-ranking/src/tests/test_fit.py`: add checkpointing-on/off tests for ranking's `val_ndcg` monitor.
+- Modify `projects/recsys-ranking/README.md`: document local Docker usage, checkpointing behavior, and dependency group behavior.
+
+---
+
+### Task 1: Dependency Policy and Lockfile
+
+**Files:**
+- Modify: `projects/recsys-ranking/pyproject.toml`
+- Modify: `projects/recsys-ranking/uv.lock`
+
+**Interfaces:**
+- Consumes: existing `[tool.uv.sources].vertex-job-runner` local path source.
+- Produces: a `vertex` dependency group available through `uv sync --group vertex` while normal Docker sync can use `--no-dev --extra=gpu` without installing `vertex-job-runner`.
+
+- [x] **Step 1: Move `vertex-job-runner` out of project dependencies**
+
+In `projects/recsys-ranking/pyproject.toml`, remove this line from `[project].dependencies`:
+
+```toml
+  "vertex-job-runner",
+```
+
+Add this dependency group:
+
+```toml
+[dependency-groups]
+dev = ["notebook~=7.5.5", "ipywidgets>=8.1.5", "tqdm~=4.67.1"]
+test = ["pytest~=9.0.3", "pytest-mock~=3.15.1", "deepdiff~=8.6.0"]
+lint = ["ruff~=0.12.11", "mypy~=1.17.1"]
+vertex = ["vertex-job-runner"]
+```
+
+Keep this source mapping unchanged:
+
+```toml
+vertex-job-runner = { path = "../../apps/vertex-job-runner", editable = true }
+```
+
+- [x] **Step 2: Decide GPU index alignment deliberately**
+
+Ranking currently uses:
+
+```toml
+[[tool.uv.index]]
+name = "pytorch-gpu"
+url = "https://download.pytorch.org/whl/cu126"
+explicit = true
+```
+
+Candidate-generation PR #159 uses `cu128`, but ranking has no PyG extension wheels. Prefer a minimal first pass: keep ranking on `cu126` unless `uv lock` or Docker build proves a TorchVision mismatch. If changing to `cu128`, update `pyproject.toml`, regenerate `uv.lock`, and include that as an explicit dependency-alignment change in the final summary.
+
+- [x] **Step 3: Regenerate lockfile**
+
+Run from the ranking package root:
+
+```sh
+cd projects/recsys-ranking
+make lock
+```
+
+Expected: `uv lock` exits 0 and `uv.lock` reflects `vertex-job-runner` under a `vertex` dependency group instead of normal package dependencies.
+
+- [x] **Step 4: Inspect the dependency diff**
+
+Run:
+
+```sh
+git diff -- projects/recsys-ranking/pyproject.toml projects/recsys-ranking/uv.lock
+```
+
+Expected: no unrelated package churn beyond the dependency group / lock resolution implied by this task.
+
+---
+
+### Task 2: Ranking Docker and WandB Local Runtime
+
+**Files:**
+- Create: `projects/recsys-ranking/Dockerfile`
+- Create: `projects/recsys-ranking/compose.yaml`
+- Create: `projects/recsys-ranking/.env.example`
+- Modify: `projects/recsys-ranking/.gitignore`
+- Modify: `projects/recsys-ranking/Makefile`
+
+**Interfaces:**
+- Consumes: `ml_sandbox_libs=../../libs/ml_sandbox_libs` as an additional Docker build context.
+- Produces: `make docker-build`, `make docker-run`, `make docker-up`, `make docker-exec`, and `make docker-down` from `projects/recsys-ranking`.
+
+- [x] **Step 1: Create ranking Dockerfile**
+
+Create `projects/recsys-ranking/Dockerfile`:
+
+```dockerfile
+# Using multi-stage build to slim down the image
+FROM --platform=linux/amd64 nvidia/cuda:12.9.1-cudnn-runtime-ubuntu24.04@sha256:d02c4310b6d57ca0b16cd80298bdb33a74187baafe2eccd8a6a16180ddc90802
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.6@sha256:b1e699368d24c57cda93c338a57a8c5a119009ba809305cc8e86986d4a006754 /uv /uvx /bin/
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+
+# Replicate monorepo structure so pyproject.toml's relative path deps resolve.
+# pyproject.toml references ../../libs/ml_sandbox_libs, which is outside the build
+# context. It is provided via an additional build context.
+# vertex-job-runner is in the 'vertex' dependency group and excluded from Docker builds.
+WORKDIR /workspace/projects/recsys-ranking
+
+COPY --from=ml_sandbox_libs . /workspace/libs/ml_sandbox_libs
+COPY pyproject.toml uv.lock .python-version ./
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project --no-dev --extra=gpu
+
+COPY ./src ./src
+
+# Disable runtime uv sync to prevent uv from checking missing editable dependencies at runtime.
+ENV UV_NO_SYNC=1
+
+WORKDIR /workspace/projects/recsys-ranking/src
+CMD ["uv", "run", "fit.py"]
+```
+
+- [x] **Step 2: Create compose config**
+
+Create `projects/recsys-ranking/compose.yaml`:
+
+```yaml
+services:
+  job:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      additional_contexts:
+        - ml_sandbox_libs=../../libs/ml_sandbox_libs
+    command: ["tail", "-f", "/dev/null"]
+    platform: linux/amd64
+    image: ${IMAGE_URI:-recsys-ranking:latest}
+    environment:
+      - WANDB_API_KEY=${WANDB_API_KEY:?WANDB_API_KEY is required}
+      - EXPERIMENT_NAME=${EXPERIMENT_NAME:-local-experiment}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0"]
+              capabilities: [gpu]
+```
+
+- [x] **Step 3: Create env example and ignore local env**
+
+Create `projects/recsys-ranking/.env.example`:
+
+```dotenv
+# Required: wandb API key for experiment tracking
+# Get yours from: https://wandb.ai/authorize
+WANDB_API_KEY=your-wandb-api-key-here
+
+# Optional: Docker image name (used by compose.yaml)
+IMAGE_URI=recsys-ranking:latest
+
+# Optional: experiment name (used by Cloud Logging in Vertex AI, not in local Docker)
+EXPERIMENT_NAME=local-experiment
+```
+
+Ensure `projects/recsys-ranking/.gitignore` contains:
+
+```gitignore
+results
+.env
+```
+
+- [x] **Step 4: Add Makefile Docker targets**
+
+Append to `projects/recsys-ranking/Makefile` after the `install` target:
+
+```make
+# Docker
+DOCKER_IMAGE ?= recsys-ranking:latest
+# Additional build context for monorepo local path dep (required by Dockerfile)
+DOCKER_BUILD_CONTEXTS := ml_sandbox_libs=../../libs/ml_sandbox_libs
+
+.PHONY: docker-build
+docker-build: ## Build the Docker image for local training
+	docker build --platform linux/amd64 --build-context $(DOCKER_BUILD_CONTEXTS) -t $(DOCKER_IMAGE) .
+
+.PHONY: docker-run
+docker-run: ## Run training directly in Docker (requires WANDB_API_KEY; Hydra args via DOCKER_ARGS)
+	@test -n "$$WANDB_API_KEY" || (echo "ERROR: WANDB_API_KEY is not set" && exit 1)
+	docker run --rm --gpus all --platform linux/amd64 \
+		-e WANDB_API_KEY=$$WANDB_API_KEY \
+		-e EXPERIMENT_NAME=$${EXPERIMENT_NAME:-local-experiment} \
+		$(DOCKER_IMAGE) uv run fit.py $(DOCKER_ARGS)
+
+.PHONY: docker-up
+docker-up: ## Start a dev shell container (use 'make docker-exec' to run training inside)
+	docker compose up -d
+
+.PHONY: docker-exec
+docker-exec: ## Run training inside the dev shell container
+	docker compose exec job uv run fit.py
+
+.PHONY: docker-down
+docker-down: ## Stop the dev shell container
+	docker compose down
+```
+
+- [x] **Step 5: Verify generated Docker commands without building**
+
+Run from the ranking package root:
+
+```sh
+cd projects/recsys-ranking
+make -n docker-build
+WANDB_API_KEY=dummy docker compose config
+```
+
+Expected:
+- `make -n docker-build` prints `docker build --platform linux/amd64 --build-context ml_sandbox_libs=../../libs/ml_sandbox_libs -t recsys-ranking:latest .`
+- `docker compose config` exits 0.
+- Compose output includes `WANDB_API_KEY: dummy`.
+- Compose output does not include `GCS_PATH`, `MOUNTED_GCS_PATH`, or volume mounts.
+
+---
+
+### Task 3: Opt-In Checkpointing for Ranking
+
+**Files:**
+- Modify: `projects/recsys-ranking/src/config/config.yaml`
+- Modify: `projects/recsys-ranking/src/fit.py`
+- Modify: `projects/recsys-ranking/src/tests/test_fit.py`
+
+**Interfaces:**
+- Consumes: Hydra key `cfg.enable_checkpointing`.
+- Produces: `fit.create_trainer(cfg, save_dir)` that disables checkpointing by default and adds `ModelCheckpoint(monitor="val_ndcg")` only when enabled.
+
+- [x] **Step 1: Add the config contract**
+
+In `projects/recsys-ranking/src/config/config.yaml`, add:
+
+```yaml
+enable_checkpointing: false
+```
+
+Place it next to `debug: true`, matching candidate-generation.
+
+- [x] **Step 2: Add failing checkpoint tests**
+
+Extend `projects/recsys-ranking/src/tests/test_fit.py` with:
+
+```python
+import pathlib
+```
+
+Add these tests:
+
+```python
+def test_create_trainer_checkpointing_disabled(mocker: MockerFixture) -> None:
+    """Trainer does not create checkpoint callbacks unless explicitly enabled."""
+    mocker.patch("fit.WandbLogger")
+
+    cfg = OmegaConf.create(
+        {
+            "model": {"name": "test_model"},
+            "device": {"accelerator": "cpu"},
+            "debug": False,
+            "log": {"log_every_n_steps": 10},
+            "optimizer": {"gradient_clip_val": 1.0},
+            "enable_checkpointing": False,
+        }
+    )
+    save_dir = pathlib.Path("/tmp/test_save_dir")
+
+    trainer = fit.create_trainer(cfg, save_dir)
+
+    from lightning.pytorch.callbacks import ModelCheckpoint
+
+    checkpoint_callbacks = [
+        c for c in cast(Any, trainer).callbacks if isinstance(c, ModelCheckpoint)
+    ]
+    assert len(checkpoint_callbacks) == 0
+
+
+def test_create_trainer_checkpointing_enabled(mocker: MockerFixture) -> None:
+    """Trainer creates a local checkpoint callback when explicitly enabled."""
+    mocker.patch("fit.WandbLogger")
+
+    cfg = OmegaConf.create(
+        {
+            "model": {"name": "test_model"},
+            "device": {"accelerator": "cpu"},
+            "debug": False,
+            "log": {"log_every_n_steps": 10},
+            "optimizer": {"gradient_clip_val": 1.0},
+            "enable_checkpointing": True,
+        }
+    )
+    save_dir = pathlib.Path("/tmp/test_save_dir")
+
+    trainer = fit.create_trainer(cfg, save_dir)
+
+    from lightning.pytorch.callbacks import ModelCheckpoint
+
+    checkpoint_callbacks = [
+        c for c in cast(Any, trainer).callbacks if isinstance(c, ModelCheckpoint)
+    ]
+    assert len(checkpoint_callbacks) == 1
+
+    checkpoint_cb = checkpoint_callbacks[0]
+    assert (
+        pathlib.Path(cast(Any, checkpoint_cb).dirpath).resolve()
+        == (save_dir / "checkpoints").resolve()
+    )
+    assert checkpoint_cb.monitor == "val_ndcg"
+    assert checkpoint_cb.mode == "max"
+    assert pathlib.Path(cast(Any, trainer).default_root_dir).resolve() == save_dir.resolve()
+```
+
+- [x] **Step 3: Run the failing targeted tests**
+
+Run:
+
+```sh
+cd projects/recsys-ranking
+uv run pytest src/tests/test_fit.py -q
+```
+
+Expected before implementation: checkpoint tests fail because `ModelCheckpoint` is still created by Lightning default behavior and `default_root_dir` is not set to `save_dir`.
+
+- [x] **Step 4: Implement checkpointing policy**
+
+In `projects/recsys-ranking/src/fit.py`, change:
+
+```python
+from lightning.pytorch.callbacks import EarlyStopping
+```
+
+to:
+
+```python
+from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint
+```
+
+Replace the inline callbacks list in `create_trainer` with:
+
+```python
+    enable_checkpointing = cfg.enable_checkpointing
+    callbacks: list[L.Callback] = [
+        EarlyStopping(monitor="val_ndcg", mode="max", patience=3),
+    ]
+    if enable_checkpointing:
+        callbacks.append(
+            ModelCheckpoint(
+                dirpath=save_dir / "checkpoints",
+                monitor="val_ndcg",
+                mode="max",
+                save_top_k=1,
+            )
+        )
+```
+
+Pass these arguments to `L.Trainer`:
+
+```python
+        callbacks=callbacks,
+        enable_checkpointing=enable_checkpointing,
+        default_root_dir=save_dir,
+```
+
+- [x] **Step 5: Run targeted tests**
+
+Run:
+
+```sh
+cd projects/recsys-ranking
+uv run pytest src/tests/test_fit.py -q
+```
+
+Expected: all tests in `src/tests/test_fit.py` pass.
+
+---
+
+### Task 4: README and Full Verification
+
+**Files:**
+- Modify: `projects/recsys-ranking/README.md`
+
+**Interfaces:**
+- Consumes: Makefile Docker targets, `.env.example`, checkpoint config key, and dependency group from Tasks 1-3.
+- Produces: user-facing instructions for local Docker, checkpoint behavior, and Vertex dependency usage.
+
+- [x] **Step 1: Add Local Docker docs**
+
+Add a `## Local Docker` section near the training section in `projects/recsys-ranking/README.md`:
+
+````markdown
+## Local Docker
+
+Dockerfile から image を build して、ローカルで学習を実行できます。
+
+### 前提
+
+- Docker（GPU アクセスのため `--gpus all` をサポート）
+- `WANDB_API_KEY` 環境変数（[wandb.ai/authorize](https://wandb.ai/authorize) から取得）
+- Dev shell では `WANDB_API_KEY` を `.env` に設定するか、`make docker-up` 実行時の shell で export してください。
+
+### image を build して学習を直接実行
+
+```sh
+export WANDB_API_KEY=your-api-key
+make docker-build
+make docker-run
+```
+
+Hydra override も渡せます:
+
+```sh
+make docker-run DOCKER_ARGS="model=DeepFM data.batch_size=32"
+```
+
+### Dev shell としての利用
+
+```sh
+cp .env.example .env
+# .env の WANDB_API_KEY を設定
+make docker-up
+make docker-exec
+make docker-down
+```
+
+### 環境変数
+
+| 変数 | 必須 | 説明 |
+|------|------|------|
+| `WANDB_API_KEY` | yes | wandb 認証用 API key |
+| `IMAGE_URI` | optional | Docker image 名（default: `recsys-ranking:latest`。`make docker-run` では `DOCKER_IMAGE` 変数を使用） |
+| `EXPERIMENT_NAME` | optional | Cloud Logging 用（ローカル Docker では使用されない） |
+````
+
+- [x] **Step 2: Document checkpointing**
+
+In the configuration area, add:
+
+```markdown
+model checkpoint は default では保存しません。
+必要な場合は `enable_checkpointing=true` を指定すると、`save_dir` 配下の `checkpoints/` に保存します。
+```
+
+- [x] **Step 3: Update dependency wording**
+
+In the dependency / shared library sections, avoid saying normal install always depends on `vertex-job-runner`. State that Vertex AI job support is available through the `vertex` dependency group.
+
+Use wording like:
+
+```markdown
+Vertex AI custom training job 連携が必要な場合は `vertex` dependency group で `vertex-job-runner` を追加します。
+```
+
+- [x] **Step 4: Run package verification**
+
+Run from the ranking package root:
+
+```sh
+cd projects/recsys-ranking
+make install
+make fmt
+make lint
+make test
+make -n docker-build
+WANDB_API_KEY=dummy docker compose config
+git diff --check
+```
+
+Expected:
+- `make install`, `make fmt`, `make lint`, and `make test` exit 0.
+- Docker dry-run uses `--build-context ml_sandbox_libs=../../libs/ml_sandbox_libs`.
+- Compose config exits 0 with `WANDB_API_KEY=dummy`.
+- `git diff --check` exits 0.
+
+- [x] **Step 5: Review final diff**
+
+Run:
+
+```sh
+git diff --stat
+git diff -- projects/recsys-ranking
+```
+
+Expected:
+- All new/changed files are under `projects/recsys-ranking`.
+- Existing `projects/recsys-candidate-generation/Makefile` user diff is still present and unchanged unless the user explicitly asked to revisit it.
+
+---
+
+## Review Gates
+
+1. After Task 1, inspect dependency churn before continuing. If `uv.lock` changes broad transitive versions unexpectedly, pause and judge whether `cu126` / `cu128` or tool-version alignment caused it.
+2. After Task 2, run only dry-run Docker checks first. Do not require a real image build unless the user asks or a reviewer needs it.
+3. After Task 3, targeted tests must pass before README changes.
+4. After Task 4, delegate a fresh `auditor` review for the full ranking diff.
+
+## Suggested Herdr Execution
+
+Use one-shot coder delegation because this is scoped implementation but touches multiple files:
+
+```sh
+HERDR_AGENT_REUSE=never herdr-agent coder "Implement docs/superpowers/plans/2026-07-03-apply-pr159-fixes-to-recsys-ranking.md for projects/recsys-ranking only. Preserve existing user changes. Do not commit."
+```
+
+Then review with a fresh auditor:
+
+```sh
+HERDR_AGENT_REUSE=never herdr-agent auditor "Review the current projects/recsys-ranking diff against docs/superpowers/plans/2026-07-03-apply-pr159-fixes-to-recsys-ranking.md. Report concrete findings with severity and evidence."
+```

--- a/projects/recsys-candidate-generation/.env.example
+++ b/projects/recsys-candidate-generation/.env.example
@@ -7,7 +7,3 @@ IMAGE_URI=recsys-candidate-generation:latest
 
 # Optional: experiment name (used by Cloud Logging in Vertex AI, not in local Docker)
 EXPERIMENT_NAME=local-experiment
-
-# Optional: GCS path (unused by training code, kept for future GCS data integration)
-GCS_PATH=/tmp/gcs
-MOUNTED_GCS_PATH=/tmp/gcs

--- a/projects/recsys-candidate-generation/.env.example
+++ b/projects/recsys-candidate-generation/.env.example
@@ -1,0 +1,14 @@
+# Required: wandb API key for experiment tracking
+# Get yours from: https://wandb.ai/authorize
+# Or extract from existing login: grep password ~/.netrc | head -1 | awk '{print $2}'
+WANDB_API_KEY=your-wandb-api-key-here
+
+# Required: Docker image name (used by compose.yaml)
+IMAGE_URI=recsys-candidate-generation:latest
+
+# Optional: experiment name (used by Cloud Logging in Vertex AI, not in local Docker)
+EXPERIMENT_NAME=local-experiment
+
+# Optional: GCS path (unused by training code, kept for future GCS data integration)
+GCS_PATH=/tmp/gcs
+MOUNTED_GCS_PATH=/tmp/gcs

--- a/projects/recsys-candidate-generation/.env.example
+++ b/projects/recsys-candidate-generation/.env.example
@@ -1,9 +1,8 @@
 # Required: wandb API key for experiment tracking
 # Get yours from: https://wandb.ai/authorize
-# Or extract from existing login: grep password ~/.netrc | head -1 | awk '{print $2}'
 WANDB_API_KEY=your-wandb-api-key-here
 
-# Required: Docker image name (used by compose.yaml)
+# Optional: Docker image name (used by compose.yaml)
 IMAGE_URI=recsys-candidate-generation:latest
 
 # Optional: experiment name (used by Cloud Logging in Vertex AI, not in local Docker)

--- a/projects/recsys-candidate-generation/.gitignore
+++ b/projects/recsys-candidate-generation/.gitignore
@@ -1,1 +1,2 @@
 results
+.env

--- a/projects/recsys-candidate-generation/Dockerfile
+++ b/projects/recsys-candidate-generation/Dockerfile
@@ -4,13 +4,27 @@ FROM --platform=linux/amd64 nvidia/cuda:12.9.1-cudnn-runtime-ubuntu24.04@sha256:
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:0.6.14@sha256:3362a526af7eca2fcd8604e6a07e873fb6e4286d8837cb753503558ce1213664 /uv /uvx /bin/
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
-# Install Python dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    --mount=type=bind,source=.python-version,target=.python-version \
-    uv sync --frozen --no-install-project --no-dev --extra=gpu
-COPY ./src /src
-WORKDIR /src
 
+# Replicate monorepo structure so pyproject.toml's relative path deps resolve.
+# pyproject.toml references ../../libs/ml_sandbox_libs, which is outside the build
+# context. It is provided via an additional build context (see compose.yaml
+# additional_contexts / Makefile docker-build --build-context).
+# Note: vertex-job-runner is in the 'vertex' dependency group and excluded from
+# Docker builds, so it does not need to be copied.
+WORKDIR /workspace/projects/recsys-candidate-generation
+
+# Copy local dependency source (needed by uv sync for editable install)
+COPY --from=ml_sandbox_libs . /workspace/libs/ml_sandbox_libs
+
+# Copy project metadata for dependency resolution
+COPY pyproject.toml uv.lock .python-version ./
+
+# Install Python dependencies (project itself is installed at runtime by `uv run`)
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project --no-dev --extra=gpu
+
+# Copy project source
+COPY ./src ./src
+
+WORKDIR /workspace/projects/recsys-candidate-generation/src
 CMD ["uv", "run", "fit.py"]

--- a/projects/recsys-candidate-generation/Dockerfile
+++ b/projects/recsys-candidate-generation/Dockerfile
@@ -26,5 +26,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Copy project source
 COPY ./src ./src
 
+# Disable runtime uv sync to prevent uv from checking missing editable dependencies at runtime.
+ENV UV_NO_SYNC=1
+
 WORKDIR /workspace/projects/recsys-candidate-generation/src
 CMD ["uv", "run", "fit.py"]

--- a/projects/recsys-candidate-generation/Dockerfile
+++ b/projects/recsys-candidate-generation/Dockerfile
@@ -2,7 +2,7 @@
 FROM --platform=linux/amd64 nvidia/cuda:12.9.1-cudnn-runtime-ubuntu24.04@sha256:d02c4310b6d57ca0b16cd80298bdb33a74187baafe2eccd8a6a16180ddc90802
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:0.6.14@sha256:3362a526af7eca2fcd8604e6a07e873fb6e4286d8837cb753503558ce1213664 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.6@sha256:b1e699368d24c57cda93c338a57a8c5a119009ba809305cc8e86986d4a006754 /uv /uvx /bin/
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 
 # Replicate monorepo structure so pyproject.toml's relative path deps resolve.

--- a/projects/recsys-candidate-generation/Makefile
+++ b/projects/recsys-candidate-generation/Makefile
@@ -2,7 +2,6 @@ include ../../make/help.mk
 include ../../make/python.mk
 
 .PHONY: install
-
 install: ## Setup the project
 	@if [ $(HAS_CUDA) -eq 1 ]; then \
 		echo "=== Install with GPU support ==="; \
@@ -15,11 +14,11 @@ install: ## Setup the project
 # ─── Docker ───────────────────────────────────────────
 DOCKER_IMAGE ?= recsys-candidate-generation:latest
 # Additional build context for monorepo local path dep (required by Dockerfile)
-DOCKER_BUILD_CONTEXTS := --build-context ml_sandbox_libs=../../libs/ml_sandbox_libs
+DOCKER_BUILD_CONTEXTS := ml_sandbox_libs=../../libs/ml_sandbox_libs
 
 .PHONY: docker-build
 docker-build: ## Build the Docker image for local training
-	docker build --platform linux/amd64 $(DOCKER_BUILD_CONTEXTS) -t $(DOCKER_IMAGE) .
+	docker build --platform linux/amd64 --build-context $(DOCKER_BUILD_CONTEXTS) -t $(DOCKER_IMAGE) .
 
 .PHONY: docker-run
 docker-run: ## Run training directly in Docker (requires WANDB_API_KEY; Hydra args via DOCKER_ARGS)

--- a/projects/recsys-candidate-generation/Makefile
+++ b/projects/recsys-candidate-generation/Makefile
@@ -11,3 +11,33 @@ install: ## Setup the project
 		echo "=== Install with CPU support ==="; \
 		uv sync --all-groups --extra=cpu; \
 	fi
+
+# ─── Docker ───────────────────────────────────────────
+DOCKER_IMAGE ?= recsys-candidate-generation:latest
+# Additional build context for monorepo local path dep (required by Dockerfile)
+DOCKER_BUILD_CONTEXTS := --build-context ml_sandbox_libs=../../libs/ml_sandbox_libs
+
+.PHONY: docker-build
+docker-build: ## Build the Docker image for local training
+	docker build --platform linux/amd64 $(DOCKER_BUILD_CONTEXTS) -t $(DOCKER_IMAGE) .
+
+.PHONY: docker-run
+docker-run: ## Run training directly in Docker (requires WANDB_API_KEY; Hydra args via DOCKER_ARGS)
+	@test -n "$$WANDB_API_KEY" || (echo "ERROR: WANDB_API_KEY is not set" && exit 1)
+	docker run --rm --gpus all --platform linux/amd64 \
+		-e WANDB_API_KEY=$$WANDB_API_KEY \
+		-e EXPERIMENT_NAME=$${EXPERIMENT_NAME:-local-experiment} \
+		$(DOCKER_IMAGE) uv run fit.py $(DOCKER_ARGS)
+
+.PHONY: docker-up
+docker-up: ## Start a dev shell container (use 'make docker-exec' to run training inside)
+	docker compose up -d
+
+.PHONY: docker-exec
+docker-exec: ## Run training inside the dev shell container
+	@test -n "$$WANDB_API_KEY" || (echo "ERROR: WANDB_API_KEY is not set" && exit 1)
+	docker compose exec job uv run fit.py
+
+.PHONY: docker-down
+docker-down: ## Stop the dev shell container
+	docker compose down

--- a/projects/recsys-candidate-generation/Makefile
+++ b/projects/recsys-candidate-generation/Makefile
@@ -35,7 +35,6 @@ docker-up: ## Start a dev shell container (use 'make docker-exec' to run trainin
 
 .PHONY: docker-exec
 docker-exec: ## Run training inside the dev shell container
-	@test -n "$$WANDB_API_KEY" || (echo "ERROR: WANDB_API_KEY is not set" && exit 1)
 	docker compose exec job uv run fit.py
 
 .PHONY: docker-down

--- a/projects/recsys-candidate-generation/README.md
+++ b/projects/recsys-candidate-generation/README.md
@@ -149,6 +149,53 @@ uv run python src/fit.py model=SimpleX
 uv run python src/fit.py model=LightGCN loss=bpr
 ```
 
+## Local Docker
+
+Dockerfile から image を build して、ローカルで学習を実行できます。
+
+### 前提
+
+- Docker（GPU アクセスのため `--gpus all` をサポート）
+- `WANDB_API_KEY` 環境変数（[wandb.ai/authorize](https://wandb.ai/authorize) から取得）
+
+### image を build して学習を直接実行
+
+```sh
+# 1. wandb API key を設定
+export WANDB_API_KEY=your-api-key
+
+# 2. image を build
+make docker-build
+
+# 3. 学習を直接実行（コンテナ内で fit.py が走る）
+make docker-run
+```
+
+Hydra override も渡せます:
+
+```sh
+make docker-run DOCKER_ARGS="model=SASRec data.batch_size=64"
+```
+
+### Dev shell としての利用
+
+コンテナを起動したまま `exec` で入ってデバッグすることもできます:
+
+```sh
+make docker-up          # dev shell 起動
+make docker-exec        # コンテナ内で学習実行
+make docker-down        # 停止
+```
+
+### 環境変数
+
+| 変数 | 必須 | 説明 |
+|------|------|------|
+| `WANDB_API_KEY` | yes | wandb 認証用 API key |
+| `IMAGE_URI` | compose のみ | Docker image 名（`make docker-run` では `DOCKER_IMAGE` 変数を使用） |
+| `EXPERIMENT_NAME` | optional | Cloud Logging 用（ローカル Docker では使用されない） |
+| `GCS_PATH` | optional | GCS マウントパス（学習コードは未使用） |
+
 ## Configuration
 
 training entrypoint は `src/fit.py` です。

--- a/projects/recsys-candidate-generation/README.md
+++ b/projects/recsys-candidate-generation/README.md
@@ -197,13 +197,13 @@ make docker-down        # 停止
 | `WANDB_API_KEY` | yes | wandb 認証用 API key |
 | `IMAGE_URI` | optional | Docker image 名（default: `recsys-candidate-generation:latest`。`make docker-run` では `DOCKER_IMAGE` 変数を使用） |
 | `EXPERIMENT_NAME` | optional | Cloud Logging 用（ローカル Docker では使用されない） |
-| `GCS_PATH` | optional | コンテナ内の GCS マウントパス（学習コードは未使用） |
-| `MOUNTED_GCS_PATH` | optional | host 側の GCS マウントパス（`compose.yaml` の volume source） |
 
 ## Configuration
 
 training entrypoint は `src/fit.py` です。
 Hydra を使って `src/config/` 配下の設定を読み込みます。
+model checkpoint は default では保存しません。
+必要な場合は `enable_checkpointing=true` を指定すると、`save_dir` 配下の `checkpoints/` に保存します。
 
 主な flow は以下です。
 

--- a/projects/recsys-candidate-generation/README.md
+++ b/projects/recsys-candidate-generation/README.md
@@ -157,6 +157,7 @@ Dockerfile から image を build して、ローカルで学習を実行でき�
 
 - Docker（GPU アクセスのため `--gpus all` をサポート）
 - `WANDB_API_KEY` 環境変数（[wandb.ai/authorize](https://wandb.ai/authorize) から取得）
+- Dev shell では `WANDB_API_KEY` を `.env` に設定するか、`make docker-up` 実行時の shell で export してください。
 
 ### image を build して学習を直接実行
 
@@ -182,6 +183,8 @@ make docker-run DOCKER_ARGS="model=SASRec data.batch_size=64"
 コンテナを起動したまま `exec` で入ってデバッグすることもできます:
 
 ```sh
+cp .env.example .env
+# .env の WANDB_API_KEY を設定
 make docker-up          # dev shell 起動
 make docker-exec        # コンテナ内で学習実行
 make docker-down        # 停止
@@ -192,9 +195,10 @@ make docker-down        # 停止
 | 変数 | 必須 | 説明 |
 |------|------|------|
 | `WANDB_API_KEY` | yes | wandb 認証用 API key |
-| `IMAGE_URI` | compose のみ | Docker image 名（`make docker-run` では `DOCKER_IMAGE` 変数を使用） |
+| `IMAGE_URI` | optional | Docker image 名（default: `recsys-candidate-generation:latest`。`make docker-run` では `DOCKER_IMAGE` 変数を使用） |
 | `EXPERIMENT_NAME` | optional | Cloud Logging 用（ローカル Docker では使用されない） |
-| `GCS_PATH` | optional | GCS マウントパス（学習コードは未使用） |
+| `GCS_PATH` | optional | コンテナ内の GCS マウントパス（学習コードは未使用） |
+| `MOUNTED_GCS_PATH` | optional | host 側の GCS マウントパス（`compose.yaml` の volume source） |
 
 ## Configuration
 

--- a/projects/recsys-candidate-generation/README.md
+++ b/projects/recsys-candidate-generation/README.md
@@ -130,7 +130,7 @@ make install
 標準の training は以下で実行します。
 
 ```sh
-make train
+uv run python src/fit.py
 ```
 
 Hydra override を使って model や data 設定を切り替えることもできます。

--- a/projects/recsys-candidate-generation/compose.yaml
+++ b/projects/recsys-candidate-generation/compose.yaml
@@ -11,9 +11,6 @@ services:
     environment:
       - WANDB_API_KEY=${WANDB_API_KEY:?WANDB_API_KEY is required}
       - EXPERIMENT_NAME=${EXPERIMENT_NAME:-local-experiment}
-      - GCS_PATH=${GCS_PATH:-/tmp/gcs}
-    volumes:
-      - ${MOUNTED_GCS_PATH:-/tmp/gcs}:${GCS_PATH:-/tmp/gcs}
     deploy:
       resources:
         reservations:

--- a/projects/recsys-candidate-generation/compose.yaml
+++ b/projects/recsys-candidate-generation/compose.yaml
@@ -7,13 +7,13 @@ services:
         - ml_sandbox_libs=../../libs/ml_sandbox_libs
     command: ["tail", "-f", "/dev/null"]
     platform: linux/amd64
-    image: ${IMAGE_URI:?error}
+    image: ${IMAGE_URI:-recsys-candidate-generation:latest}
     environment:
       - WANDB_API_KEY=${WANDB_API_KEY:?WANDB_API_KEY is required}
       - EXPERIMENT_NAME=${EXPERIMENT_NAME:-local-experiment}
       - GCS_PATH=${GCS_PATH:-/tmp/gcs}
     volumes:
-      - ${MOUNTED_GCS_PATH:-/tmp/gcs}:${MOUNTED_GCS_PATH:-/tmp/gcs}
+      - ${MOUNTED_GCS_PATH:-/tmp/gcs}:${GCS_PATH:-/tmp/gcs}
     deploy:
       resources:
         reservations:

--- a/projects/recsys-candidate-generation/compose.yaml
+++ b/projects/recsys-candidate-generation/compose.yaml
@@ -3,14 +3,17 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      additional_contexts:
+        - ml_sandbox_libs=../../libs/ml_sandbox_libs
     command: ["tail", "-f", "/dev/null"]
     platform: linux/amd64
     image: ${IMAGE_URI:?error}
     environment:
-      - GCS_PATH=${GCS_PATH:?error}
-      - EXPERIMENT_NAME=${EXPERIMENT_NAME:?error}
+      - WANDB_API_KEY=${WANDB_API_KEY:?WANDB_API_KEY is required}
+      - EXPERIMENT_NAME=${EXPERIMENT_NAME:-local-experiment}
+      - GCS_PATH=${GCS_PATH:-/tmp/gcs}
     volumes:
-      - ${MOUNTED_GCS_PATH:?error}:${MOUNTED_GCS_PATH:?error}
+      - ${MOUNTED_GCS_PATH:-/tmp/gcs}:${MOUNTED_GCS_PATH:-/tmp/gcs}
     deploy:
       resources:
         reservations:

--- a/projects/recsys-candidate-generation/pyproject.toml
+++ b/projects/recsys-candidate-generation/pyproject.toml
@@ -38,7 +38,7 @@ gpu = [
 [dependency-groups]
 dev = ["notebook~=7.5.5", "ipywidgets>=8.1.5", "tqdm~=4.67.1"]
 test = ["pytest~=9.0.3", "pytest-mock~=3.15.1", "deepdiff~=8.6.2"]
-lint = ["ruff~=0.11.4", "mypy~=1.14.0"]
+lint = ["ruff~=0.15.12", "mypy~=1.20.2"]
 vertex = ["vertex-job-runner"]
 
 [tool.uv]

--- a/projects/recsys-candidate-generation/pyproject.toml
+++ b/projects/recsys-candidate-generation/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
   "wandb~=0.25.1",
   "timm~=1.0.15",
   "ml-sandbox-libs",
-  "vertex-job-runner",
 ]
 
 [project.optional-dependencies]
@@ -38,6 +37,7 @@ gpu = [
 dev = ["notebook~=7.5.5", "ipywidgets>=8.1.5", "tqdm~=4.67.1"]
 test = ["pytest~=9.0.3", "pytest-mock~=3.15.1", "deepdiff~=8.6.2"]
 lint = ["ruff~=0.11.4", "mypy~=1.14.0"]
+vertex = ["vertex-job-runner"]
 
 [tool.uv]
 conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]

--- a/projects/recsys-candidate-generation/pyproject.toml
+++ b/projects/recsys-candidate-generation/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 [project.optional-dependencies]
 cpu = [
     "torch==2.11.0",
+    "torchvision==0.26.0",
     "pyg_lib",
     "torch_scatter",
     "torch_sparse",
@@ -27,6 +28,7 @@ cpu = [
 ]
 gpu = [
   "torch==2.11.0",
+  "torchvision==0.26.0",
   "pyg_lib",
   "torch_scatter",
   "torch_sparse",
@@ -46,6 +48,11 @@ conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]
 ml-sandbox-libs = { path = "../../libs/ml_sandbox_libs", editable = true }
 vertex-job-runner = { path = "../../apps/vertex-job-runner", editable = true }
 torch = [
+  { index = "pytorch-cpu-mac", extra = "cpu", marker = "platform_system == 'Darwin'" },
+  { index = "pytorch-cpu", extra = "cpu", marker = "platform_system != 'Darwin'" },
+  { index = "pytorch-gpu", extra = "gpu" },
+]
+torchvision = [
   { index = "pytorch-cpu-mac", extra = "cpu", marker = "platform_system == 'Darwin'" },
   { index = "pytorch-cpu", extra = "cpu", marker = "platform_system != 'Darwin'" },
   { index = "pytorch-gpu", extra = "gpu" },

--- a/projects/recsys-candidate-generation/src/config/config.yaml
+++ b/projects/recsys-candidate-generation/src/config/config.yaml
@@ -6,6 +6,7 @@ defaults:
 
 save_dir: ./results/
 debug: true
+enable_checkpointing: false
 
 device:
   accelerator: gpu

--- a/projects/recsys-candidate-generation/src/fit.py
+++ b/projects/recsys-candidate-generation/src/fit.py
@@ -4,7 +4,7 @@ from typing import cast
 
 import hydra
 import lightning as L
-from lightning.pytorch.callbacks import EarlyStopping
+from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint
 from lightning.pytorch.loggers import WandbLogger
 from ml_sandbox_libs.data.amazon_reviews_dataset import (
     AmazonReviewsBipartiteGraphDataModule,
@@ -39,13 +39,27 @@ def create_trainer(cfg: DictConfig, save_dir: pathlib.Path) -> L.Trainer:
 
     devices = [cfg.device.accelerator_no] if cfg.device.accelerator == "gpu" else "auto"
 
+    enable_checkpointing = cfg.enable_checkpointing
+    callbacks: list[L.Callback] = [
+        EarlyStopping(monitor="val_hit_rate", mode="max", patience=3),
+    ]
+    if enable_checkpointing:
+        callbacks.append(
+            ModelCheckpoint(
+                dirpath=save_dir / "checkpoints",
+                monitor="val_hit_rate",
+                mode="max",
+                save_top_k=1,
+            )
+        )
+
     return L.Trainer(
         max_epochs=10,
         accelerator=cfg.device.accelerator,
         devices=devices,
-        callbacks=[
-            EarlyStopping(monitor="val_hit_rate", mode="max", patience=3),
-        ],
+        callbacks=callbacks,
+        enable_checkpointing=enable_checkpointing,
+        default_root_dir=save_dir,
         detect_anomaly=True,
         fast_dev_run=10 if cfg.debug else False,
         enable_progress_bar=False,

--- a/projects/recsys-candidate-generation/src/tests/test_fit.py
+++ b/projects/recsys-candidate-generation/src/tests/test_fit.py
@@ -1,5 +1,6 @@
 """Tests for candidate-generation fit orchestration helpers."""
 
+import pathlib
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -27,3 +28,64 @@ def test_build_module_prepares_datamodule_before_factory_dispatch(
     datamodule.prepare_data.assert_called_once_with()
     create_optimizer.assert_called_once_with(cfg)
     create_model_module.assert_called_once_with(cfg, datamodule, optimizer)
+
+
+def test_create_trainer_checkpointing_disabled(mocker: MockerFixture) -> None:
+    """Test that trainer is configured with checkpointing disabled by default."""
+    mocker.patch("fit.WandbLogger")
+
+    cfg = OmegaConf.create(
+        {
+            "model": {"name": "test_model"},
+            "device": {"accelerator": "cpu"},
+            "debug": False,
+            "log": {"log_every_n_steps": 10},
+            "optimizer": {"gradient_clip_val": 1.0},
+            "enable_checkpointing": False,
+        }
+    )
+    save_dir = pathlib.Path("/tmp/test_save_dir")
+
+    trainer = fit.create_trainer(cfg, save_dir)
+
+    from lightning.pytorch.callbacks import ModelCheckpoint
+
+    checkpoint_callbacks = [
+        c for c in cast(Any, trainer).callbacks if isinstance(c, ModelCheckpoint)
+    ]
+    assert len(checkpoint_callbacks) == 0
+
+
+def test_create_trainer_checkpointing_enabled(mocker: MockerFixture) -> None:
+    """Test that trainer is configured with checkpointing enabled and correct paths when requested."""
+    mocker.patch("fit.WandbLogger")
+
+    cfg = OmegaConf.create(
+        {
+            "model": {"name": "test_model"},
+            "device": {"accelerator": "cpu"},
+            "debug": False,
+            "log": {"log_every_n_steps": 10},
+            "optimizer": {"gradient_clip_val": 1.0},
+            "enable_checkpointing": True,
+        }
+    )
+    save_dir = pathlib.Path("/tmp/test_save_dir")
+
+    trainer = fit.create_trainer(cfg, save_dir)
+
+    from lightning.pytorch.callbacks import ModelCheckpoint
+
+    checkpoint_callbacks = [
+        c for c in cast(Any, trainer).callbacks if isinstance(c, ModelCheckpoint)
+    ]
+    assert len(checkpoint_callbacks) == 1
+
+    checkpoint_cb = checkpoint_callbacks[0]
+    assert (
+        pathlib.Path(cast(Any, checkpoint_cb).dirpath).resolve()
+        == (save_dir / "checkpoints").resolve()
+    )
+    assert checkpoint_cb.monitor == "val_hit_rate"
+    assert checkpoint_cb.mode == "max"
+    assert pathlib.Path(cast(Any, trainer).default_root_dir).resolve() == save_dir.resolve()

--- a/projects/recsys-candidate-generation/src/tests/test_models/test_simple_x.py
+++ b/projects/recsys-candidate-generation/src/tests/test_models/test_simple_x.py
@@ -114,7 +114,7 @@ def test_simplex_forward_returns_expected_shapes(simplex: SimpleX) -> None:
 @pytest.mark.parametrize("user_id_weight", [-0.1, 1.1])
 def test_simplex_validates_user_id_weight(user_id_weight: float) -> None:
     """Rejects user ID fusion weights outside the valid range."""
-    with pytest.raises(ValueError, match="between 0.0 and 1.0"):
+    with pytest.raises(ValueError, match=r"between 0.0 and 1.0"):
         SimpleX(
             out_dim=8,
             num_users=20,

--- a/projects/recsys-candidate-generation/uv.lock
+++ b/projects/recsys-candidate-generation/uv.lock
@@ -1272,6 +1272,27 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/e0/dbd0f2a68a1c1a1991eb7921ff6014465d56608cdc9a9fb468a616210a37/librt-0.12.0.tar.gz", hash = "sha256:cb26faedbd09c6130e9c1b64d8000efec5076ffd18d606c6cd1cf02730e6d8b0", size = 203841, upload-time = "2026-06-30T16:14:29.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/1a/5bec493821b0e85b91de4f234912b50133d1aedb875048eef27938ec3f96/librt-0.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9bce19aa7c05f91c989f9da7b567f81d21d57a2e6501e2b811aa0f3f79614c1a", size = 146756, upload-time = "2026-06-30T16:12:44.395Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d0/cc04b48a57c1f275387f5578847214c4a6c21bfb24c6c8c8d6ba753fe403/librt-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0ace09f5bf4d982fe726015f102fb856658b41580597104e301e630ed1d8d86", size = 145537, upload-time = "2026-06-30T16:12:45.95Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/10/c02325556beb2aa158c9e549ddade8cc9a23b36cdad14756dbed730c1ff1/librt-0.12.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d007efe9243ede81ce75990ad7aa172da1e2024144b3eff17ba46a5fff1fff3c", size = 488637, upload-time = "2026-06-30T16:12:47.658Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9e/7b49ca1c30baa9c8df96024aa09a97c35a97455e36004c9b5311703c56f3/librt-0.12.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:ad324a5e4858388a4864915b90a42efc8b374376393f14b9940f2454e791912b", size = 483651, upload-time = "2026-06-30T16:12:49.283Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/71/03c8c8cec39645fda451132ff9d6d662fc5aea42a1a188a77a4fddb35906/librt-0.12.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10a40cf74cdd97b6f8f905056db73f5d459783de2ca04c6ebd1bf47652818e7e", size = 518359, upload-time = "2026-06-30T16:12:50.999Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ec/a9f357f94bbcba92277d22af22cff42ef706ae5d9d6d58b69bebf3a67954/librt-0.12.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:92e61c09de95217ae02a9d17f4f66cf073253cdc51bcfdc0f15c62c9a70baa85", size = 509510, upload-time = "2026-06-30T16:12:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/34/717055325d028743aa01a7691ad59a63352a26a8ff2e7eeb0c9249514150/librt-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0461344061d6fc3718940f5855d95647831cef6d03a6c7506897f98222784ad4", size = 527302, upload-time = "2026-06-30T16:12:54.244Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f8/7612eeedb3395d92f7c6a84dca5f15e282d650483a4dc01aa5b9cffdfda3/librt-0.12.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e6dfe89074732c9287b3c0f5a6af575c9ede380a788013876cc7b14fe0da0361", size = 532568, upload-time = "2026-06-30T16:12:55.74Z" },
+    { url = "https://files.pythonhosted.org/packages/79/1e/a9afe85d5bb8b65dc27be3809ed1d69082079e1e9717fd2c66aa9939600c/librt-0.12.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9efed79d51ad1383bba0855f613cca7aa91c943e709af2413ac7f4bb9936ce08", size = 521579, upload-time = "2026-06-30T16:12:57.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1e/93aebb219d52c37ea578f83b0588cd7b040974e464d4e435086a48b4dc4d/librt-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1eac6cc0e23e448fb3c1446ed85ff796afb616eed5897c978d35dbec030b7c7c", size = 558743, upload-time = "2026-06-30T16:12:59.577Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/85/1680c0ec332f238e3145c5608d313ab0a43281e210a5dd87e3bc3cc25631/librt-0.12.0-cp312-cp312-win32.whl", hash = "sha256:0ab8ee0210047ae86ca023ccfbfe3df82077fd1c9bc021aebbf37d993ef64af0", size = 99200, upload-time = "2026-06-30T16:13:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/30/0e/abca12d8904875aa2ad66327390a3f7b1b75ebc43c0a00fc763cecf32ea5/librt-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:51c8bfa12632c81b94401c101bcedd0c56c3a1f8fa3273ca3472b28cd2f54003", size = 119390, upload-time = "2026-06-30T16:13:02.493Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a5/4203481b6d3a3bb348c82ac71abf1fcb4cb3ae8422a24a8dee4cd3ac5bd7/librt-0.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:5eebd451f5def089369ba6d8ff0291303d035e8154f9f26f7633835c5b029ade", size = 105117, upload-time = "2026-06-30T16:13:03.952Z" },
+]
+
+[[package]]
 name = "lightning"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1506,21 +1527,24 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.14.1"
+version = "1.20.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
     { name = "mypy-extensions" },
+    { name = "pathspec" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/eb/2c92d8ea1e684440f54fa49ac5d9a5f19967b7b472a281f419e69a8d228e/mypy-1.14.1.tar.gz", hash = "sha256:7ec88144fe9b510e8475ec2f5f251992690fcf89ccb4500b214b4226abcd32d6", size = 3216051, upload-time = "2024-12-30T16:39:07.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/1b/b38c079609bb4627905b74fc6a49849835acf68547ac33d8ceb707de5f52/mypy-1.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30ff5ef8519bbc2e18b3b54521ec319513a26f1bba19a7582e7b1f58a6e69f14", size = 11266668, upload-time = "2024-12-30T16:38:02.211Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/75/2ed0d2964c1ffc9971c729f7a544e9cd34b2cdabbe2d11afd148d7838aa2/mypy-1.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cb9f255c18052343c70234907e2e532bc7e55a62565d64536dbc7706a20b78b9", size = 10254060, upload-time = "2024-12-30T16:37:46.131Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/5f/7b8051552d4da3c51bbe8fcafffd76a6823779101a2b198d80886cd8f08e/mypy-1.14.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b4e3413e0bddea671012b063e27591b953d653209e7a4fa5e48759cda77ca11", size = 11933167, upload-time = "2024-12-30T16:37:43.534Z" },
-    { url = "https://files.pythonhosted.org/packages/04/90/f53971d3ac39d8b68bbaab9a4c6c58c8caa4d5fd3d587d16f5927eeeabe1/mypy-1.14.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:553c293b1fbdebb6c3c4030589dab9fafb6dfa768995a453d8a5d3b23784af2e", size = 12864341, upload-time = "2024-12-30T16:37:36.249Z" },
-    { url = "https://files.pythonhosted.org/packages/03/d2/8bc0aeaaf2e88c977db41583559319f1821c069e943ada2701e86d0430b7/mypy-1.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fad79bfe3b65fe6a1efaed97b445c3d37f7be9fdc348bdb2d7cac75579607c89", size = 12972991, upload-time = "2024-12-30T16:37:06.743Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/17/07815114b903b49b0f2cf7499f1c130e5aa459411596668267535fe9243c/mypy-1.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:8fa2220e54d2946e94ab6dbb3ba0a992795bd68b16dc852db33028df2b00191b", size = 9879016, upload-time = "2024-12-30T16:37:15.02Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/b5/32dd67b69a16d088e533962e5044e51004176a9952419de0370cdaead0f8/mypy-1.14.1-py3-none-any.whl", hash = "sha256:b66a60cc4073aeb8ae00057f9c1f64d49e90f918fbcef9a977eb121da8b8f1d1", size = 2752905, upload-time = "2024-12-30T16:38:42.021Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4e/7560e4528db9e9b147e4c0f22660466bf30a0a1fe3d63d1b9d3b0fd354ee/mypy-1.20.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4dbfcf869f6b0517f70cf0030ba6ea1d6645e132337a7d5204a18d8d5636c02b", size = 14539393, upload-time = "2026-04-21T17:07:12.52Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d9/34a5efed8124f5a9234f55ac6a4ced4201e2c5b81e1109c49ad23190ec8c/mypy-1.20.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b6481b228d072315b053210b01ac320e1be243dc17f9e5887ef167f23f5fae4", size = 13361642, upload-time = "2026-04-21T17:06:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/14/eb377acf78c03c92d566a1510cda8137348215b5335085ef662ab82ecd3a/mypy-1.20.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34397cdced6b90b836e38182076049fdb41424322e0b0728c946b0939ebdf9f6", size = 13740347, upload-time = "2026-04-21T17:12:04.73Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/94/7e4634a32b641aa1c112422eed1bbece61ee16205f674190e8b536f884de/mypy-1.20.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5da6976f20cae27059ea8d0c86e7cef3de720e04c4bb9ee18e3690fdb792066", size = 14734042, upload-time = "2026-04-21T17:07:43.16Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f3/f7e62395cb7f434541b4491a01149a4439e28ace4c0c632bbf5431e92d1f/mypy-1.20.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56908d7e08318d39f85b1f0c6cfd47b0cac1a130da677630dac0de3e0623e102", size = 14964958, upload-time = "2026-04-21T17:11:00.665Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0d/47e3c3a0ec2a876e35aeac365df3cac7776c36bbd4ed18cc521e1b9d255b/mypy-1.20.2-cp312-cp312-win_amd64.whl", hash = "sha256:d52ad8d78522da1d308789df651ee5379088e77c76cb1994858d40a426b343b9", size = 10911340, upload-time = "2026-04-21T17:10:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/b2/6c852d72e0ea8b01f49da817fb52539993cde327e7d010e0103dc12d0dac/mypy-1.20.2-cp312-cp312-win_arm64.whl", hash = "sha256:785b08db19c9f214dc37d65f7c165d19a30fcecb48abfa30f31b01b5acaabb58", size = 9833947, upload-time = "2026-04-21T17:09:05.267Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/f23c163e25b11074188251b0b5a0342625fc1cdb6af604757174fa9acc9b/mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563", size = 2637314, upload-time = "2026-04-21T17:05:54.5Z" },
 ]
 
 [[package]]
@@ -2122,6 +2146,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d", size = 400609, upload-time = "2024-04-05T09:43:55.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18", size = 103650, upload-time = "2024-04-05T09:43:53.299Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -2732,8 +2765,8 @@ dev = [
     { name = "tqdm", specifier = "~=4.67.1" },
 ]
 lint = [
-    { name = "mypy", specifier = "~=1.14.0" },
-    { name = "ruff", specifier = "~=0.11.4" },
+    { name = "mypy", specifier = "~=1.20.2" },
+    { name = "ruff", specifier = "~=0.15.12" },
 ]
 test = [
     { name = "deepdiff", specifier = "~=8.6.2" },
@@ -2840,27 +2873,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.11.5"
+version = "0.15.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/71/5759b2a6b2279bb77fe15b1435b89473631c2cd6374d45ccdb6b785810be/ruff-0.11.5.tar.gz", hash = "sha256:cae2e2439cb88853e421901ec040a758960b576126dab520fa08e9de431d1bef", size = 3976488, upload-time = "2025-04-10T17:13:29.369Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/db/6efda6381778eec7f35875b5cbefd194904832a1153d68d36d6b269d81a8/ruff-0.11.5-py3-none-linux_armv6l.whl", hash = "sha256:2561294e108eb648e50f210671cc56aee590fb6167b594144401532138c66c7b", size = 10103150, upload-time = "2025-04-10T17:12:37.886Z" },
-    { url = "https://files.pythonhosted.org/packages/44/f2/06cd9006077a8db61956768bc200a8e52515bf33a8f9b671ee527bb10d77/ruff-0.11.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac12884b9e005c12d0bd121f56ccf8033e1614f736f766c118ad60780882a077", size = 10898637, upload-time = "2025-04-10T17:12:41.602Z" },
-    { url = "https://files.pythonhosted.org/packages/18/f5/af390a013c56022fe6f72b95c86eb7b2585c89cc25d63882d3bfe411ecf1/ruff-0.11.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4bfd80a6ec559a5eeb96c33f832418bf0fb96752de0539905cf7b0cc1d31d779", size = 10236012, upload-time = "2025-04-10T17:12:44.584Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/ca/b9bf954cfed165e1a0c24b86305d5c8ea75def256707f2448439ac5e0d8b/ruff-0.11.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0947c0a1afa75dcb5db4b34b070ec2bccee869d40e6cc8ab25aca11a7d527794", size = 10415338, upload-time = "2025-04-10T17:12:47.172Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/4d/2522dde4e790f1b59885283f8786ab0046958dfd39959c81acc75d347467/ruff-0.11.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ad871ff74b5ec9caa66cb725b85d4ef89b53f8170f47c3406e32ef040400b038", size = 9965277, upload-time = "2025-04-10T17:12:50.628Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/7a/749f56f150eef71ce2f626a2f6988446c620af2f9ba2a7804295ca450397/ruff-0.11.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e6cf918390cfe46d240732d4d72fa6e18e528ca1f60e318a10835cf2fa3dc19f", size = 11541614, upload-time = "2025-04-10T17:12:53.783Z" },
-    { url = "https://files.pythonhosted.org/packages/89/b2/7d9b8435222485b6aac627d9c29793ba89be40b5de11584ca604b829e960/ruff-0.11.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:56145ee1478582f61c08f21076dc59153310d606ad663acc00ea3ab5b2125f82", size = 12198873, upload-time = "2025-04-10T17:12:56.956Z" },
-    { url = "https://files.pythonhosted.org/packages/00/e0/a1a69ef5ffb5c5f9c31554b27e030a9c468fc6f57055886d27d316dfbabd/ruff-0.11.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e5f66f8f1e8c9fc594cbd66fbc5f246a8d91f916cb9667e80208663ec3728304", size = 11670190, upload-time = "2025-04-10T17:13:00.194Z" },
-    { url = "https://files.pythonhosted.org/packages/05/61/c1c16df6e92975072c07f8b20dad35cd858e8462b8865bc856fe5d6ccb63/ruff-0.11.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80b4df4d335a80315ab9afc81ed1cff62be112bd165e162b5eed8ac55bfc8470", size = 13902301, upload-time = "2025-04-10T17:13:03.246Z" },
-    { url = "https://files.pythonhosted.org/packages/79/89/0af10c8af4363304fd8cb833bd407a2850c760b71edf742c18d5a87bb3ad/ruff-0.11.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3068befab73620b8a0cc2431bd46b3cd619bc17d6f7695a3e1bb166b652c382a", size = 11350132, upload-time = "2025-04-10T17:13:06.209Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/e1/ecb4c687cbf15164dd00e38cf62cbab238cad05dd8b6b0fc68b0c2785e15/ruff-0.11.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5da2e710a9641828e09aa98b92c9ebbc60518fdf3921241326ca3e8f8e55b8b", size = 10312937, upload-time = "2025-04-10T17:13:08.855Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/4f/0e53fe5e500b65934500949361e3cd290c5ba60f0324ed59d15f46479c06/ruff-0.11.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ef39f19cb8ec98cbc762344921e216f3857a06c47412030374fffd413fb8fd3a", size = 9936683, upload-time = "2025-04-10T17:13:11.378Z" },
-    { url = "https://files.pythonhosted.org/packages/04/a8/8183c4da6d35794ae7f76f96261ef5960853cd3f899c2671961f97a27d8e/ruff-0.11.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b2a7cedf47244f431fd11aa5a7e2806dda2e0c365873bda7834e8f7d785ae159", size = 10950217, upload-time = "2025-04-10T17:13:14.565Z" },
-    { url = "https://files.pythonhosted.org/packages/26/88/9b85a5a8af21e46a0639b107fcf9bfc31da4f1d263f2fc7fbe7199b47f0a/ruff-0.11.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:81be52e7519f3d1a0beadcf8e974715b2dfc808ae8ec729ecfc79bddf8dbb783", size = 11404521, upload-time = "2025-04-10T17:13:17.8Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/52/047f35d3b20fd1ae9ccfe28791ef0f3ca0ef0b3e6c1a58badd97d450131b/ruff-0.11.5-py3-none-win32.whl", hash = "sha256:e268da7b40f56e3eca571508a7e567e794f9bfcc0f412c4b607931d3af9c4afe", size = 10320697, upload-time = "2025-04-10T17:13:20.582Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/fe/00c78010e3332a6e92762424cf4c1919065707e962232797d0b57fd8267e/ruff-0.11.5-py3-none-win_amd64.whl", hash = "sha256:6c6dc38af3cfe2863213ea25b6dc616d679205732dc0fb673356c2d69608f800", size = 11378665, upload-time = "2025-04-10T17:13:23.349Z" },
-    { url = "https://files.pythonhosted.org/packages/43/7c/c83fe5cbb70ff017612ff36654edfebec4b1ef79b558b8e5fd933bab836b/ruff-0.11.5-py3-none-win_arm64.whl", hash = "sha256:67e241b4314f4eacf14a601d586026a962f4002a475aa702c69980a38087aa4e", size = 10460287, upload-time = "2025-04-10T17:13:26.538Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
 ]
 
 [[package]]

--- a/projects/recsys-candidate-generation/uv.lock
+++ b/projects/recsys-candidate-generation/uv.lock
@@ -2646,7 +2646,6 @@ dependencies = [
     { name = "timm" },
     { name = "torchinfo" },
     { name = "torchmetrics" },
-    { name = "vertex-job-runner" },
     { name = "wandb" },
 ]
 
@@ -2686,6 +2685,9 @@ test = [
     { name = "pytest" },
     { name = "pytest-mock" },
 ]
+vertex = [
+    { name = "vertex-job-runner" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2713,7 +2715,6 @@ requires-dist = [
     { name = "torch-sparse", marker = "extra == 'gpu'", url = "https://data.pyg.org/whl/torch-2.11.0%2Bcu128/torch_sparse-0.6.18%2Bpt211cu128-cp312-cp312-linux_x86_64.whl" },
     { name = "torchinfo", specifier = "~=1.8.0" },
     { name = "torchmetrics", specifier = "~=1.9.0" },
-    { name = "vertex-job-runner", editable = "../../apps/vertex-job-runner" },
     { name = "wandb", specifier = "~=0.25.1" },
 ]
 provides-extras = ["cpu", "gpu"]
@@ -2733,6 +2734,7 @@ test = [
     { name = "pytest", specifier = "~=9.0.3" },
     { name = "pytest-mock", specifier = "~=3.15.1" },
 ]
+vertex = [{ name = "vertex-job-runner", editable = "../../apps/vertex-job-runner" }]
 
 [[package]]
 name = "referencing"
@@ -3700,8 +3702,8 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 lint = [
-    { name = "mypy", specifier = "~=1.14.1" },
-    { name = "ruff", specifier = "~=0.8.4" },
+    { name = "mypy", specifier = "~=1.20.2" },
+    { name = "ruff", specifier = "~=0.15.12" },
 ]
 test = [
     { name = "pytest", specifier = "~=9.0.3" },

--- a/projects/recsys-candidate-generation/uv.lock
+++ b/projects/recsys-candidate-generation/uv.lock
@@ -2661,6 +2661,8 @@ cpu = [
     { name = "torch-scatter", version = "2.1.2+pt211cpu", source = { url = "https://data.pyg.org/whl/torch-2.11.0%2Bcpu/torch_scatter-2.1.2%2Bpt211cpu-cp312-cp312-linux_x86_64.whl" }, marker = "(sys_platform != 'darwin' and extra == 'extra-27-recsys-candidate-generation-cpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
     { name = "torch-sparse", version = "0.6.18", source = { url = "https://data.pyg.org/whl/torch-2.11.0%2Bcpu/torch_sparse-0.6.18-cp312-cp312-macosx_11_0_universal2.whl" }, marker = "(sys_platform == 'darwin' and extra == 'extra-27-recsys-candidate-generation-cpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
     { name = "torch-sparse", version = "0.6.18+pt211cpu", source = { url = "https://data.pyg.org/whl/torch-2.11.0%2Bcpu/torch_sparse-0.6.18%2Bpt211cpu-cp312-cp312-linux_x86_64.whl" }, marker = "(sys_platform != 'darwin' and extra == 'extra-27-recsys-candidate-generation-cpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "torchvision", version = "0.26.0", source = { registry = "https://pypi.python.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'extra-27-recsys-candidate-generation-cpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "torchvision", version = "0.26.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-27-recsys-candidate-generation-cpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 gpu = [
     { name = "pyg-lib", version = "0.6.0+pt211cu128", source = { url = "https://data.pyg.org/whl/torch-2.11.0%2Bcu128/pyg_lib-0.6.0%2Bpt211cu128-cp312-cp312-manylinux_2_28_x86_64.whl" } },
@@ -2668,6 +2670,7 @@ gpu = [
     { name = "torch-cluster", version = "1.6.3+pt211cu128", source = { url = "https://data.pyg.org/whl/torch-2.11.0%2Bcu128/torch_cluster-1.6.3%2Bpt211cu128-cp312-cp312-linux_x86_64.whl" } },
     { name = "torch-scatter", version = "2.1.2+pt211cu128", source = { url = "https://data.pyg.org/whl/torch-2.11.0%2Bcu128/torch_scatter-2.1.2%2Bpt211cu128-cp312-cp312-linux_x86_64.whl" } },
     { name = "torch-sparse", version = "0.6.18+pt211cu128", source = { url = "https://data.pyg.org/whl/torch-2.11.0%2Bcu128/torch_sparse-0.6.18%2Bpt211cu128-cp312-cp312-linux_x86_64.whl" } },
+    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
 ]
 
 [package.dev-dependencies]
@@ -2715,6 +2718,9 @@ requires-dist = [
     { name = "torch-sparse", marker = "extra == 'gpu'", url = "https://data.pyg.org/whl/torch-2.11.0%2Bcu128/torch_sparse-0.6.18%2Bpt211cu128-cp312-cp312-linux_x86_64.whl" },
     { name = "torchinfo", specifier = "~=1.8.0" },
     { name = "torchmetrics", specifier = "~=1.9.0" },
+    { name = "torchvision", marker = "sys_platform == 'darwin' and extra == 'cpu'", specifier = "==0.26.0", index = "https://pypi.python.org/simple", conflict = { package = "recsys-candidate-generation", extra = "cpu" } },
+    { name = "torchvision", marker = "sys_platform != 'darwin' and extra == 'cpu'", specifier = "==0.26.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "recsys-candidate-generation", extra = "cpu" } },
+    { name = "torchvision", marker = "extra == 'gpu'", specifier = "==0.26.0", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "recsys-candidate-generation", extra = "gpu" } },
     { name = "wandb", specifier = "~=0.25.1" },
 ]
 provides-extras = ["cpu", "gpu"]
@@ -3102,7 +3108,10 @@ dependencies = [
     { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-27-recsys-candidate-generation-cpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
     { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-27-recsys-candidate-generation-gpu'" },
     { name = "torchvision", version = "0.21.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
-    { name = "torchvision", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' or extra == 'extra-27-recsys-candidate-generation-cpu' or extra == 'extra-27-recsys-candidate-generation-gpu'" },
+    { name = "torchvision", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "torchvision", version = "0.26.0", source = { registry = "https://pypi.python.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'extra-27-recsys-candidate-generation-cpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "torchvision", version = "0.26.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-27-recsys-candidate-generation-cpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-27-recsys-candidate-generation-gpu'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bc/0c/66b0f9b4a4cb9ffdac7b52b17b37c7d3c4f75623b469e388b0c6d89b4e88/timm-1.0.15.tar.gz", hash = "sha256:756a3bc30c96565f056e608a9b559daed904617eaadb6be536f96874879b1055", size = 2230258, upload-time = "2025-02-23T05:05:55.959Z" }
 wheels = [
@@ -3523,26 +3532,75 @@ name = "torchvision"
 version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu'",
-    "sys_platform != 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu'",
-    "sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu'",
-    "sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu'",
-    "sys_platform == 'darwin' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu'",
-    "sys_platform != 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu'",
+    "sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'linux' or extra == 'extra-27-recsys-candidate-generation-cpu' or extra == 'extra-27-recsys-candidate-generation-gpu'" },
-    { name = "pillow", marker = "sys_platform != 'linux' or extra == 'extra-27-recsys-candidate-generation-cpu' or extra == 'extra-27-recsys-candidate-generation-gpu'" },
+    { name = "numpy", marker = "(sys_platform != 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "pillow", marker = "(sys_platform != 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
     { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.python.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'extra-27-recsys-candidate-generation-cpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
-    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-27-recsys-candidate-generation-cpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-27-recsys-candidate-generation-gpu'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/e7/56b47cc3b132aea90ccce22bcb8975dec688b002150012acc842846039d0/torchvision-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c409e1c3fdebec7a3834465086dbda8bf7680eff79abf7fd2f10c6b59520a7a4", size = 1863502, upload-time = "2026-03-23T18:12:57.326Z" },
     { url = "https://files.pythonhosted.org/packages/f4/ec/5c31c92c08b65662fe9604a4067ae8232582805949f11ddc042cebe818ed/torchvision-0.26.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:406557718e62fdf10f5706e88d8a5ec000f872da913bf629aab9297622585547", size = 7767944, upload-time = "2026-03-23T18:12:42.805Z" },
     { url = "https://files.pythonhosted.org/packages/f5/d8/cb6ccda1a1f35a6597645818641701207b3e8e13553e75fce5d86bac74b2/torchvision-0.26.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d61a5abb6b42a0c0c311996c2ac4b83a94418a97182c83b055a2a4ae985e05aa", size = 7522205, upload-time = "2026-03-23T18:12:54.654Z" },
     { url = "https://files.pythonhosted.org/packages/1c/a9/c272623a0f735c35f0f6cd6dc74784d4f970e800cf063bb76687895a2ab9/torchvision-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:7993c01648e7c61d191b018e84d38fe0825c8fcb2720cd0f37caf7ba14404aa1", size = 4255155, upload-time = "2026-03-23T18:12:32.652Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.26.0"
+source = { registry = "https://pypi.python.org/simple" }
+resolution-markers = [
+    "sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "numpy", marker = "(sys_platform == 'darwin' and extra == 'extra-27-recsys-candidate-generation-cpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "pillow", marker = "(sys_platform == 'darwin' and extra == 'extra-27-recsys-candidate-generation-cpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.python.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'extra-27-recsys-candidate-generation-cpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/e7/56b47cc3b132aea90ccce22bcb8975dec688b002150012acc842846039d0/torchvision-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c409e1c3fdebec7a3834465086dbda8bf7680eff79abf7fd2f10c6b59520a7a4", size = 1863502, upload-time = "2026-03-23T18:12:57.326Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ec/5c31c92c08b65662fe9604a4067ae8232582805949f11ddc042cebe818ed/torchvision-0.26.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:406557718e62fdf10f5706e88d8a5ec000f872da913bf629aab9297622585547", size = 7767944, upload-time = "2026-03-23T18:12:42.805Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d8/cb6ccda1a1f35a6597645818641701207b3e8e13553e75fce5d86bac74b2/torchvision-0.26.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d61a5abb6b42a0c0c311996c2ac4b83a94418a97182c83b055a2a4ae985e05aa", size = 7522205, upload-time = "2026-03-23T18:12:54.654Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a9/c272623a0f735c35f0f6cd6dc74784d4f970e800cf063bb76687895a2ab9/torchvision-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:7993c01648e7c61d191b018e84d38fe0825c8fcb2720cd0f37caf7ba14404aa1", size = 4255155, upload-time = "2026-03-23T18:12:32.652Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.26.0+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "sys_platform == 'linux'",
+    "sys_platform != 'darwin' and sys_platform != 'linux'",
+]
+dependencies = [
+    { name = "numpy", marker = "(sys_platform != 'darwin' and extra == 'extra-27-recsys-candidate-generation-cpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "pillow", marker = "(sys_platform != 'darwin' and extra == 'extra-27-recsys-candidate-generation-cpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-27-recsys-candidate-generation-cpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.26.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:17f0b542331fc94230b4214c6d123f038af7330fd81019608c0d2402f3bc3079", upload-time = "2026-03-23T15:36:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.26.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:cf547dc0975eb40bc3249be4ccbeb736597d2c3ece305b1c4e5b7a5dd7363567", upload-time = "2026-03-23T15:36:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.26.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:52aa8401850a9792e71a8a1e65ac004e2b23622a6b6fd278cd11179efbefc65b", upload-time = "2026-03-23T15:36:09Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.26.0+cu128"
+source = { registry = "https://download.pytorch.org/whl/cu128" }
+resolution-markers = [
+    "sys_platform == 'linux'",
+    "sys_platform != 'linux'",
+]
+dependencies = [
+    { name = "numpy", marker = "extra == 'extra-27-recsys-candidate-generation-gpu'" },
+    { name = "pillow", marker = "extra == 'extra-27-recsys-candidate-generation-gpu'" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-27-recsys-candidate-generation-gpu'" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:63e35234aed13b6edda37056f417b5c281249669db631e706811917af36b21d7", upload-time = "2026-04-09T23:21:35Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ccf26b4b659cfce6f2208cb8326071d51c70219a34856dfdf468d1e19af52c0d", upload-time = "2026-03-23T15:36:22Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:8c0d1c4fbb2c9a4d5d41d0aaa87da20e525bcb2a154ce405725b0be59456804b", upload-time = "2026-04-09T23:21:36Z" },
 ]
 
 [[package]]

--- a/projects/recsys-ranking/.env.example
+++ b/projects/recsys-ranking/.env.example
@@ -1,0 +1,9 @@
+# Required: wandb API key for experiment tracking
+# Get yours from: https://wandb.ai/authorize
+WANDB_API_KEY=your-wandb-api-key-here
+
+# Optional: Docker image name (used by compose.yaml)
+IMAGE_URI=recsys-ranking:latest
+
+# Optional: experiment name (used by Cloud Logging in Vertex AI, not in local Docker)
+EXPERIMENT_NAME=local-experiment

--- a/projects/recsys-ranking/.gitignore
+++ b/projects/recsys-ranking/.gitignore
@@ -1,1 +1,2 @@
 results
+.env

--- a/projects/recsys-ranking/Dockerfile
+++ b/projects/recsys-ranking/Dockerfile
@@ -1,0 +1,26 @@
+# Using multi-stage build to slim down the image
+FROM --platform=linux/amd64 nvidia/cuda:12.9.1-cudnn-runtime-ubuntu24.04@sha256:d02c4310b6d57ca0b16cd80298bdb33a74187baafe2eccd8a6a16180ddc90802
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.6@sha256:b1e699368d24c57cda93c338a57a8c5a119009ba809305cc8e86986d4a006754 /uv /uvx /bin/
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+
+# Replicate monorepo structure so pyproject.toml's relative path deps resolve.
+# pyproject.toml references ../../libs/ml_sandbox_libs, which is outside the build
+# context. It is provided via an additional build context.
+# vertex-job-runner is in the 'vertex' dependency group and excluded from Docker builds.
+WORKDIR /workspace/projects/recsys-ranking
+
+COPY --from=ml_sandbox_libs . /workspace/libs/ml_sandbox_libs
+COPY pyproject.toml uv.lock .python-version ./
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project --no-dev --extra=gpu
+
+COPY ./src ./src
+
+# Disable runtime uv sync to prevent uv from checking missing editable dependencies at runtime.
+ENV UV_NO_SYNC=1
+
+WORKDIR /workspace/projects/recsys-ranking/src
+CMD ["uv", "run", "fit.py"]

--- a/projects/recsys-ranking/Makefile
+++ b/projects/recsys-ranking/Makefile
@@ -11,3 +11,32 @@ install: ## Setup the project
 		echo "=== Install with CPU support ==="; \
 		uv sync --all-groups --extra=cpu; \
 	fi
+
+# Docker
+DOCKER_IMAGE ?= recsys-ranking:latest
+# Additional build context for monorepo local path dep (required by Dockerfile)
+DOCKER_BUILD_CONTEXTS := ml_sandbox_libs=../../libs/ml_sandbox_libs
+
+.PHONY: docker-build
+docker-build: ## Build the Docker image for local training
+	docker build --platform linux/amd64 --build-context $(DOCKER_BUILD_CONTEXTS) -t $(DOCKER_IMAGE) .
+
+.PHONY: docker-run
+docker-run: ## Run training directly in Docker (requires WANDB_API_KEY; Hydra args via DOCKER_ARGS)
+	@test -n "$$WANDB_API_KEY" || (echo "ERROR: WANDB_API_KEY is not set" && exit 1)
+	docker run --rm --gpus all --platform linux/amd64 \
+		-e WANDB_API_KEY=$$WANDB_API_KEY \
+		-e EXPERIMENT_NAME=$${EXPERIMENT_NAME:-local-experiment} \
+		$(DOCKER_IMAGE) uv run fit.py $(DOCKER_ARGS)
+
+.PHONY: docker-up
+docker-up: ## Start a dev shell container (use 'make docker-exec' to run training inside)
+	docker compose up -d
+
+.PHONY: docker-exec
+docker-exec: ## Run training inside the dev shell container
+	docker compose exec job uv run fit.py
+
+.PHONY: docker-down
+docker-down: ## Stop the dev shell container
+	docker compose down

--- a/projects/recsys-ranking/README.md
+++ b/projects/recsys-ranking/README.md
@@ -153,7 +153,7 @@ make test
 基本の学習実行は次の通りです。
 
 ```sh
-make train
+uv run python src/fit.py
 ```
 
 Hydra の override を使って個別設定を変更することもできます。

--- a/projects/recsys-ranking/README.md
+++ b/projects/recsys-ranking/README.md
@@ -171,6 +171,57 @@ uv run python src/fit.py model=DeepFM data.batch_size=32
 
 使用可能な設定名は `src/config` と `src/models/factory` の対応に従います。
 
+### Checkpoint
+
+model checkpoint は default では保存しません。
+必要な場合は `enable_checkpointing=true` を指定すると、`save_dir` 配下の `checkpoints/` に保存します。
+
+```sh
+uv run python src/fit.py enable_checkpointing=true
+```
+
+## Local Docker
+
+Dockerfile から image を build して、ローカルで学習を実行できます。
+
+### 前提
+
+- Docker（GPU アクセスのため `--gpus all` をサポート）
+- `WANDB_API_KEY` 環境変数（[wandb.ai/authorize](https://wandb.ai/authorize) から取得）
+- Dev shell では `WANDB_API_KEY` を `.env` に設定するか、`make docker-up` 実行時の shell で export してください。
+
+### image を build して学習を直接実行
+
+```sh
+export WANDB_API_KEY=your-api-key
+make docker-build
+make docker-run
+```
+
+Hydra override も渡せます:
+
+```sh
+make docker-run DOCKER_ARGS="model=DeepFM data.batch_size=32"
+```
+
+### Dev shell としての利用
+
+```sh
+cp .env.example .env
+# .env の WANDB_API_KEY を設定
+make docker-up
+make docker-exec
+make docker-down
+```
+
+### 環境変数
+
+| 変数 | 必須 | 説明 |
+|------|------|------|
+| `WANDB_API_KEY` | yes | wandb 認証用 API key |
+| `IMAGE_URI` | optional | Docker image 名（default: `recsys-ranking:latest`。`make docker-run` では `DOCKER_IMAGE` 変数を使用） |
+| `EXPERIMENT_NAME` | optional | Cloud Logging 用（ローカル Docker では使用されない） |
+
 ## Dependencies
 
 この package は主に以下の依存を利用します。
@@ -183,13 +234,13 @@ uv run python src/fit.py model=DeepFM data.batch_size=32
 - `wandb`
 - `timm`
 - `ml-sandbox-libs`
-- `vertex-job-runner`
 
 また、`cpu` / `gpu` の optional dependency を通じて PyTorch と torchvision を切り替える構成です。
+Vertex AI custom training job 連携が必要な場合は `vertex` dependency group で `vertex-job-runner` を追加します。
 
 ## Relationship with Shared Libraries
 
-共通化されたコンポーネントは主に `libs/ml_sandbox_libs` と `apps/vertex-job-runner` から参照します。
+共通化されたコンポーネントは主に `libs/ml_sandbox_libs` と `apps/vertex-job-runner`（`vertex` dependency group）から参照します。
 
 - `ml_sandbox_libs`: DataModule、shared datamodule factory、共通 model module、optimizer、training utility
 - `vertex-job-runner`: Vertex AI 上での job 実行補助

--- a/projects/recsys-ranking/compose.yaml
+++ b/projects/recsys-ranking/compose.yaml
@@ -1,0 +1,20 @@
+services:
+  job:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      additional_contexts:
+        - ml_sandbox_libs=../../libs/ml_sandbox_libs
+    command: ["tail", "-f", "/dev/null"]
+    platform: linux/amd64
+    image: ${IMAGE_URI:-recsys-ranking:latest}
+    environment:
+      - WANDB_API_KEY=${WANDB_API_KEY:?WANDB_API_KEY is required}
+      - EXPERIMENT_NAME=${EXPERIMENT_NAME:-local-experiment}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0"]
+              capabilities: [gpu]

--- a/projects/recsys-ranking/pyproject.toml
+++ b/projects/recsys-ranking/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
   "wandb~=0.25.1",
   "timm~=1.0.19",
   "ml-sandbox-libs",
-  "vertex-job-runner",
 ]
 
 [project.optional-dependencies]
@@ -27,6 +26,7 @@ gpu = ["torch==2.11.0", "torchvision==0.26.0"]
 dev = ["notebook~=7.5.5", "ipywidgets>=8.1.5", "tqdm~=4.67.1"]
 test = ["pytest~=9.0.3", "pytest-mock~=3.15.1", "deepdiff~=8.6.0"]
 lint = ["ruff~=0.12.11", "mypy~=1.17.1"]
+vertex = ["vertex-job-runner"]
 
 [tool.uv]
 conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]

--- a/projects/recsys-ranking/src/config/config.yaml
+++ b/projects/recsys-ranking/src/config/config.yaml
@@ -6,6 +6,7 @@ defaults:
 
 save_dir: ./results/
 debug: true
+enable_checkpointing: false
 
 device:
   accelerator: gpu

--- a/projects/recsys-ranking/src/fit.py
+++ b/projects/recsys-ranking/src/fit.py
@@ -4,7 +4,7 @@ from typing import cast
 
 import hydra
 import lightning as L
-from lightning.pytorch.callbacks import EarlyStopping
+from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint
 from lightning.pytorch.loggers import WandbLogger
 from ml_sandbox_libs.data.amazon_reviews_dataset import AmazonReviewsSeqRecDataModule
 from ml_sandbox_libs.data.factory import create_seq_rec_datamodule
@@ -37,13 +37,27 @@ def create_trainer(cfg: DictConfig, save_dir: pathlib.Path) -> L.Trainer:
 
     devices = [cfg.device.accelerator_no] if cfg.device.accelerator == "gpu" else "auto"
 
+    enable_checkpointing = cfg.enable_checkpointing
+    callbacks: list[L.Callback] = [
+        EarlyStopping(monitor="val_ndcg", mode="max", patience=3),
+    ]
+    if enable_checkpointing:
+        callbacks.append(
+            ModelCheckpoint(
+                dirpath=save_dir / "checkpoints",
+                monitor="val_ndcg",
+                mode="max",
+                save_top_k=1,
+            )
+        )
+
     return L.Trainer(
         max_epochs=10,
         accelerator=cfg.device.accelerator,
         devices=devices,
-        callbacks=[
-            EarlyStopping(monitor="val_ndcg", mode="max", patience=3),
-        ],
+        callbacks=callbacks,
+        enable_checkpointing=enable_checkpointing,
+        default_root_dir=save_dir,
         detect_anomaly=True,
         fast_dev_run=10 if cfg.debug else False,
         enable_progress_bar=False,

--- a/projects/recsys-ranking/src/tests/test_fit.py
+++ b/projects/recsys-ranking/src/tests/test_fit.py
@@ -1,5 +1,6 @@
 """Tests for ranking fit orchestration helpers."""
 
+import pathlib
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -41,3 +42,64 @@ def test_build_module_prepares_datamodule_before_creating_dependencies(
         neg_sample_size=cfg.data.neg_sample_size,
     )
     create_model_module.assert_called_once_with(cfg, datamodule, optimizer, loss_fn)
+
+
+def test_create_trainer_checkpointing_disabled(mocker: MockerFixture) -> None:
+    """Trainer does not create checkpoint callbacks unless explicitly enabled."""
+    mocker.patch("fit.WandbLogger")
+
+    cfg = OmegaConf.create(
+        {
+            "model": {"name": "test_model"},
+            "device": {"accelerator": "cpu"},
+            "debug": False,
+            "log": {"log_every_n_steps": 10},
+            "optimizer": {"gradient_clip_val": 1.0},
+            "enable_checkpointing": False,
+        }
+    )
+    save_dir = pathlib.Path("/tmp/test_save_dir")
+
+    trainer = fit.create_trainer(cfg, save_dir)
+
+    from lightning.pytorch.callbacks import ModelCheckpoint
+
+    checkpoint_callbacks = [
+        c for c in cast(Any, trainer).callbacks if isinstance(c, ModelCheckpoint)
+    ]
+    assert len(checkpoint_callbacks) == 0
+
+
+def test_create_trainer_checkpointing_enabled(mocker: MockerFixture) -> None:
+    """Trainer creates a local checkpoint callback when explicitly enabled."""
+    mocker.patch("fit.WandbLogger")
+
+    cfg = OmegaConf.create(
+        {
+            "model": {"name": "test_model"},
+            "device": {"accelerator": "cpu"},
+            "debug": False,
+            "log": {"log_every_n_steps": 10},
+            "optimizer": {"gradient_clip_val": 1.0},
+            "enable_checkpointing": True,
+        }
+    )
+    save_dir = pathlib.Path("/tmp/test_save_dir")
+
+    trainer = fit.create_trainer(cfg, save_dir)
+
+    from lightning.pytorch.callbacks import ModelCheckpoint
+
+    checkpoint_callbacks = [
+        c for c in cast(Any, trainer).callbacks if isinstance(c, ModelCheckpoint)
+    ]
+    assert len(checkpoint_callbacks) == 1
+
+    checkpoint_cb = checkpoint_callbacks[0]
+    assert (
+        pathlib.Path(cast(Any, checkpoint_cb).dirpath).resolve()
+        == (save_dir / "checkpoints").resolve()
+    )
+    assert checkpoint_cb.monitor == "val_ndcg"
+    assert checkpoint_cb.mode == "max"
+    assert pathlib.Path(cast(Any, trainer).default_root_dir).resolve() == save_dir.resolve()

--- a/projects/recsys-ranking/uv.lock
+++ b/projects/recsys-ranking/uv.lock
@@ -2710,7 +2710,6 @@ dependencies = [
     { name = "timm" },
     { name = "torchinfo" },
     { name = "torchmetrics" },
-    { name = "vertex-job-runner" },
     { name = "wandb" },
 ]
 
@@ -2741,6 +2740,9 @@ test = [
     { name = "pytest" },
     { name = "pytest-mock" },
 ]
+vertex = [
+    { name = "vertex-job-runner" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2760,7 +2762,6 @@ requires-dist = [
     { name = "torchvision", marker = "sys_platform == 'darwin' and extra == 'cpu'", specifier = "==0.26.0", index = "https://pypi.python.org/simple", conflict = { package = "recsys-ranking", extra = "cpu" } },
     { name = "torchvision", marker = "sys_platform != 'darwin' and extra == 'cpu'", specifier = "==0.26.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "recsys-ranking", extra = "cpu" } },
     { name = "torchvision", marker = "extra == 'gpu'", specifier = "==0.26.0", index = "https://download.pytorch.org/whl/cu126", conflict = { package = "recsys-ranking", extra = "gpu" } },
-    { name = "vertex-job-runner", editable = "../../apps/vertex-job-runner" },
     { name = "wandb", specifier = "~=0.25.1" },
 ]
 provides-extras = ["cpu", "gpu"]
@@ -2780,6 +2781,7 @@ test = [
     { name = "pytest", specifier = "~=9.0.3" },
     { name = "pytest-mock", specifier = "~=3.15.1" },
 ]
+vertex = [{ name = "vertex-job-runner", editable = "../../apps/vertex-job-runner" }]
 
 [[package]]
 name = "referencing"
@@ -3628,8 +3630,8 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 lint = [
-    { name = "mypy", specifier = "~=1.14.1" },
-    { name = "ruff", specifier = "~=0.8.4" },
+    { name = "mypy", specifier = "~=1.20.2" },
+    { name = "ruff", specifier = "~=0.15.12" },
 ]
 test = [
     { name = "pytest", specifier = "~=9.0.3" },


### PR DESCRIPTION
## Summary
- **candidate-generation の Docker build context 整理**: Makefile の build context 変数を key=value に限定し、`--build-context` は docker build 側で明示しました。
- **candidate-generation のローカル Docker/W&B 修正**: monorepo local dependency を Docker additional build contexts で解決し、`UV_NO_SYNC=1`、W&B 認証 env、runtime dependency 整理、checkpoint opt-in を導入しました。
- **ranking への横展開**: `projects/recsys-ranking` に Dockerfile / compose / Makefile targets / `.env.example` を追加し、W&B 認証付きの local Docker 実行を可能にしました。
- **ranking の training policy 整理**: `vertex-job-runner` を `vertex` dependency group に移動し、checkpoint を `enable_checkpointing=true` の明示指定時のみ `save_dir/checkpoints` に保存するようにしました。
- **docs/tests 更新**: ranking README と checkpointing tests を追加し、実装 plan も記録しました。

## Test Plan
- `cd projects/recsys-candidate-generation && make lint && make test`
- `cd projects/recsys-ranking && make lint`
- `cd projects/recsys-ranking && make test` (154 passed)
- `cd projects/recsys-ranking && make -n docker-build`
- `cd projects/recsys-ranking && WANDB_API_KEY=dummy docker compose config`
- `git diff --check`