### PR TITLE
feat: Vertex AI ジョブへの W&B API key 受け渡し対応と Amazon Reviews の UCSD 直接取得移行

### DIFF
--- a/apps/vertex-job-runner/README.md
+++ b/apps/vertex-job-runner/README.md
@@ -197,6 +197,7 @@ make test
 
 - Vertex AI や GCS を利用するため、Google Cloud 側の認証設定が必要です。
 - `service_account`、`project`、SDK staging/output 用の `gcs_uri` は実際の環境に合わせて設定してください。
+- `gcs_uri` は Vertex AI SDK の `staging_bucket` / `base_output_dir` 用であり、training container の環境変数 `GCS_URI` としては渡されません（破壊的変更）。container 内で GCS パスを参照する必要がある場合は、別途コマンド引数などで渡してください。
 - W&B を使う training container では、実行前に `VRUN_WANDB_API_KEY` を設定してください。これは container 内では `WANDB_API_KEY` として参照されます。
 - 本番用途では `image_uri` に固定タグ付きイメージを使うと再現性を保ちやすくなります。
 - 機密情報を `pyproject.toml` に直接書かないようにし、必要に応じて環境変数や Secret Manager を利用してください。

--- a/apps/vertex-job-runner/README.md
+++ b/apps/vertex-job-runner/README.md
@@ -86,7 +86,7 @@ args = ["trainer.max_epochs=10", "data.num_workers=4"]
 - `project`: GCP project ID
 - `location`: Vertex AI のリージョン
 - `image_uri`: 実行するコンテナイメージ
-- `gcs_uri`: staging や成果物出力に利用する GCS URI
+- `gcs_uri`: Vertex AI SDK の staging bucket と base output dir に利用する GCS URI
 - `service_account`: ジョブ実行に利用するサービスアカウント
 - `experiment_name`: Vertex AI 上のジョブ名プレフィックス
 - `command`: コンテナ内で実行するコマンド
@@ -104,7 +104,12 @@ export VRUN_PROJECT="my-project"
 export VRUN_LOCATION="us-central1"
 export VRUN_MACHINE_TYPE="n1-highmem-8"
 export VRUN_ACCELERATOR_COUNT="2"
+export VRUN_WANDB_API_KEY="your-wandb-api-key"
 ```
+
+`VRUN_WANDB_API_KEY` を設定すると、Vertex AI の training container には `WANDB_API_KEY` として渡されます。`pyproject.toml` には API key を書かず、shell・CI secret・Secret Manager などから環境変数として渡してください。
+
+なお、container 環境変数として渡された `WANDB_API_KEY` は Vertex AI の job 詳細や監査ログ上で参照可能です。より高いセキュリティが必要な場合は、Secret Manager 経由で取得するなどの代替手段を検討してください。
 
 たとえば CI やローカル検証で project や machine type だけを差し替えたいときに便利です。
 
@@ -191,7 +196,8 @@ make test
 ## 注意事項
 
 - Vertex AI や GCS を利用するため、Google Cloud 側の認証設定が必要です。
-- `service_account`、`project`、`gcs_uri` は実際の環境に合わせて設定してください。
+- `service_account`、`project`、SDK staging/output 用の `gcs_uri` は実際の環境に合わせて設定してください。
+- W&B を使う training container では、実行前に `VRUN_WANDB_API_KEY` を設定してください。これは container 内では `WANDB_API_KEY` として参照されます。
 - 本番用途では `image_uri` に固定タグ付きイメージを使うと再現性を保ちやすくなります。
 - 機密情報を `pyproject.toml` に直接書かないようにし、必要に応じて環境変数や Secret Manager を利用してください。
 

--- a/apps/vertex-job-runner/pyproject.toml
+++ b/apps/vertex-job-runner/pyproject.toml
@@ -18,7 +18,11 @@ dependencies = [
 vrun = "vertex_job_runner.cli:app"
 
 [dependency-groups]
-test = ["pytest~=9.0.3", "pytest-console-scripts~=1.4.1"]
+test = [
+    "pytest~=9.0.3",
+    "pytest-console-scripts~=1.4.1",
+    "pytest-mock~=3.15",
+]
 lint = ["ruff~=0.15.15", "mypy~=1.20.2"]
 
 [tool.uv]

--- a/apps/vertex-job-runner/samples/.env.local
+++ b/apps/vertex-job-runner/samples/.env.local
@@ -4,3 +4,6 @@ VRUN_IMAGE_URI="us-docker.pkg.dev/ml-sandbox/command/job-runner:latest"
 VRUN_GCS_URI="gs://haru256-ml-sandbox-vertex-ai-training/sample"
 VRUN_EXPERIMENT_NAME="job-runner-sample"
 VRUN_SERVICE_ACCOUNT="job-runner@haru256-ml-sandbox.com"
+
+# W&B API key for training containers. Do not commit real values.
+# VRUN_WANDB_API_KEY=your-wandb-api-key

--- a/apps/vertex-job-runner/src/vertex_job_runner/job.py
+++ b/apps/vertex-job-runner/src/vertex_job_runner/job.py
@@ -19,7 +19,6 @@ def run_custom_training_job(settings: Settings) -> str:
     Returns:
         The Vertex AI training pipeline resource name.
     """
-    # This function would contain the logic to submit the job using the Google Cloud AI Platform SDK.
     suffix = datetime.now().strftime("%Y%m%d%H%M%S")
     job = aiplatform.CustomContainerTrainingJob(
         display_name=f"{settings.experiment_name}_{suffix}",

--- a/apps/vertex-job-runner/src/vertex_job_runner/job.py
+++ b/apps/vertex-job-runner/src/vertex_job_runner/job.py
@@ -6,7 +6,19 @@ from vertex_job_runner.settings import Settings
 
 
 def run_custom_training_job(settings: Settings) -> str:
-    """Run a custom training job to Vertex AI."""
+    """Run a custom training job on Vertex AI.
+
+    The training container always receives `PROJECT` and `EXPERIMENT_NAME` as
+    environment variables. If `settings.wandb_api_key` is set, it is injected as
+    `WANDB_API_KEY`. `GCS_URI` is intentionally not passed to the container;
+    `gcs_uri` is only used for Vertex AI SDK staging/output.
+
+    Args:
+        settings: The configured job settings.
+
+    Returns:
+        The Vertex AI training pipeline resource name.
+    """
     # This function would contain the logic to submit the job using the Google Cloud AI Platform SDK.
     suffix = datetime.now().strftime("%Y%m%d%H%M%S")
     job = aiplatform.CustomContainerTrainingJob(
@@ -17,6 +29,13 @@ def run_custom_training_job(settings: Settings) -> str:
         staging_bucket=settings.gcs_uri,
         command=settings.command,
     )
+    environment_variables = {
+        "PROJECT": settings.project,
+        "EXPERIMENT_NAME": settings.experiment_name,
+    }
+    if settings.wandb_api_key is not None:
+        environment_variables["WANDB_API_KEY"] = settings.wandb_api_key.get_secret_value()
+
     job.run(
         service_account=settings.service_account,
         machine_type=settings.machine_type,
@@ -26,11 +45,7 @@ def run_custom_training_job(settings: Settings) -> str:
         base_output_dir=settings.gcs_uri,
         disable_retries=True,
         args=settings.args,  # type: ignore
-        environment_variables={
-            "PROJECT": settings.project,
-            "EXPERIMENT_NAME": settings.experiment_name,
-            "GCS_URI": settings.gcs_uri,
-        },
+        environment_variables=environment_variables,
     )
 
     return job.resource_name

--- a/apps/vertex-job-runner/src/vertex_job_runner/settings.py
+++ b/apps/vertex-job-runner/src/vertex_job_runner/settings.py
@@ -1,7 +1,7 @@
 import shlex
 from typing import Any, List, Optional, Tuple, Type
 
-from pydantic import Field, field_validator
+from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, PyprojectTomlConfigSettingsSource, SettingsConfigDict
 
 
@@ -27,6 +27,10 @@ class Settings(BaseSettings):
         default=..., description="The service account email to run the job"
     )
     experiment_name: str = Field(default=..., description="The name of the Vertex AI experiment")
+    wandb_api_key: SecretStr | None = Field(
+        default=None,
+        description="The W&B API key to pass to the training container",
+    )
     command: List[str] = Field(default=..., description="The command to run inside the container")
 
     # Items overridable by arguments

--- a/apps/vertex-job-runner/tests/test_cli.py
+++ b/apps/vertex-job-runner/tests/test_cli.py
@@ -1,6 +1,12 @@
 import re
+from typing import Any
 
+import pytest
 from pytest_console_scripts import ScriptRunner
+from pytest_mock import MockerFixture
+
+from vertex_job_runner.job import run_custom_training_job
+from vertex_job_runner.settings import Settings
 
 PRG = "vrun"
 
@@ -16,12 +22,33 @@ def strip_ansi(text: str) -> str:
     return ansi_escape.sub("", text)
 
 
+def make_settings(**overrides: Any) -> Settings:
+    """Create Settings for job unit tests."""
+    values: dict[str, Any] = {
+        "project": "test-project",
+        "location": "us-central1",
+        "image_uri": "us-docker.pkg.dev/test/image:latest",
+        "gcs_uri": "gs://test-bucket/vertex/",
+        "service_account": "trainer@test-project.iam.gserviceaccount.com",
+        "experiment_name": "test-experiment",
+        "command": ["uv", "run", "python", "src/fit.py"],
+        "machine_type": "g2-standard-4",
+        "accelerator_type": "NVIDIA_L4",
+        "accelerator_count": 1,
+        "args": ["model=SASRec"],
+    }
+    values.update(overrides)
+    return Settings(**values)
+
+
 def test_help(script_runner: ScriptRunner) -> None:
+    """Test that the CLI prints usage information for the --help flag."""
     result = script_runner.run([PRG, "--help"], check=True)
     assert re.search(rf"Usage: {PRG}", strip_ansi(result.stdout)) is not None
 
 
 def test_dry_run_config_loading(script_runner: ScriptRunner) -> None:
+    """Test that dry-run mode loads and displays values from pyproject.toml and environment variables."""
     result = script_runner.run([PRG, "--dry-run"], check=True)
     # Check if command is correctly split into a list in the output table
     assert "['uv', 'run', 'main.py']" in result.stdout
@@ -30,5 +57,71 @@ def test_dry_run_config_loading(script_runner: ScriptRunner) -> None:
 
 
 def test_cli_args_override(script_runner: ScriptRunner) -> None:
+    """Test that CLI --args overrides the default args in the dry-run output."""
     result = script_runner.run([PRG, "--args", "param1=val1 param2=val2", "--dry-run"], check=True)
     assert "['param1=val1', 'param2=val2']" in result.stdout
+
+
+def test_run_custom_training_job_passes_wandb_api_key_without_gcs_env(
+    mocker: MockerFixture,
+) -> None:
+    """Test that WANDB_API_KEY is passed to the container and GCS_URI is not.
+
+    Also verifies that gcs_uri is still supplied to the Vertex AI SDK constructor
+    and run() kwargs for staging_bucket and base_output_dir.
+    """
+    settings = make_settings(wandb_api_key="secret-wandb-key")
+    mock_job = mocker.MagicMock()
+    mock_job.resource_name = "projects/test/locations/us-central1/trainingPipelines/123"
+
+    mock_cls = mocker.patch("vertex_job_runner.job.aiplatform.CustomContainerTrainingJob")
+    mock_cls.return_value = mock_job
+    resource_name = run_custom_training_job(settings)
+
+    assert resource_name == "projects/test/locations/us-central1/trainingPipelines/123"
+    _, ctor_kwargs = mock_cls.call_args
+    assert ctor_kwargs["staging_bucket"] == "gs://test-bucket/vertex/"
+    assert ctor_kwargs["container_uri"] == "us-docker.pkg.dev/test/image:latest"
+    _, run_kwargs = mock_job.run.call_args
+    assert run_kwargs["base_output_dir"] == "gs://test-bucket/vertex/"
+    assert run_kwargs["environment_variables"] == {
+        "PROJECT": "test-project",
+        "EXPERIMENT_NAME": "test-experiment",
+        "WANDB_API_KEY": "secret-wandb-key",
+    }
+    assert "GCS_URI" not in run_kwargs["environment_variables"]
+
+
+def test_run_custom_training_job_omits_wandb_api_key_when_unset(
+    mocker: MockerFixture,
+) -> None:
+    """Test that WANDB_API_KEY is omitted from container env vars when not configured."""
+    settings = make_settings()
+    mock_job = mocker.MagicMock()
+    mock_job.resource_name = "projects/test/locations/us-central1/trainingPipelines/456"
+
+    mock_cls = mocker.patch("vertex_job_runner.job.aiplatform.CustomContainerTrainingJob")
+    mock_cls.return_value = mock_job
+    run_custom_training_job(settings)
+
+    _, ctor_kwargs = mock_cls.call_args
+    assert ctor_kwargs["staging_bucket"] == "gs://test-bucket/vertex/"
+    _, run_kwargs = mock_job.run.call_args
+    assert run_kwargs["base_output_dir"] == "gs://test-bucket/vertex/"
+    assert run_kwargs["environment_variables"] == {
+        "PROJECT": "test-project",
+        "EXPERIMENT_NAME": "test-experiment",
+    }
+
+
+def test_env_var_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that VRUN_ prefixed environment variables override pyproject.toml defaults."""
+    monkeypatch.setenv("VRUN_PROJECT", "env-project")
+    monkeypatch.setenv("VRUN_MACHINE_TYPE", "n1-standard-8")
+    monkeypatch.setenv("VRUN_ACCELERATOR_COUNT", "2")
+
+    settings = Settings()
+
+    assert settings.project == "env-project"
+    assert settings.machine_type == "n1-standard-8"
+    assert settings.accelerator_count == 2

--- a/apps/vertex-job-runner/tests/test_cli.py
+++ b/apps/vertex-job-runner/tests/test_cli.py
@@ -119,9 +119,12 @@ def test_env_var_override(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("VRUN_PROJECT", "env-project")
     monkeypatch.setenv("VRUN_MACHINE_TYPE", "n1-standard-8")
     monkeypatch.setenv("VRUN_ACCELERATOR_COUNT", "2")
+    monkeypatch.setenv("VRUN_WANDB_API_KEY", "env-wandb-key")
 
     settings = Settings()
 
     assert settings.project == "env-project"
     assert settings.machine_type == "n1-standard-8"
     assert settings.accelerator_count == 2
+    assert settings.wandb_api_key is not None
+    assert settings.wandb_api_key.get_secret_value() == "env-wandb-key"

--- a/apps/vertex-job-runner/uv.lock
+++ b/apps/vertex-job-runner/uv.lock
@@ -971,6 +971,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1145,6 +1157,7 @@ lint = [
 test = [
     { name = "pytest" },
     { name = "pytest-console-scripts" },
+    { name = "pytest-mock" },
 ]
 
 [package.metadata]
@@ -1164,6 +1177,7 @@ lint = [
 test = [
     { name = "pytest", specifier = "~=9.0.3" },
     { name = "pytest-console-scripts", specifier = "~=1.4.1" },
+    { name = "pytest-mock", specifier = "~=3.15" },
 ]
 
 [[package]]

--- a/docs/superpowers/plans/2026-07-04-pytest-mock-addition.md
+++ b/docs/superpowers/plans/2026-07-04-pytest-mock-addition.md
@@ -1,0 +1,47 @@
+# Pytest Mock Addition
+
+plan body not authored in this workflow
+
+## Implementation Log
+<!-- Implementer appends one line per attempt: [YYYY-MM-DD] attempt #N -> STATUS | commit-or-failure-signature -->
+- [2026-07-04] attempt #2 -> DONE | no commit (F3/F4 only)
+
+## Review Findings
+<!-- This template is also defined in commands/plan.md. Keep them in sync on every edit. -->
+
+### Reviewer Raw Findings
+<!-- Orchestrator copies @reviewer's structured findings verbatim here when invoking @reviewer during a workflow. Direct /review-* calls do not write here. Raw findings are review input, not implementation instructions. -->
+
+#### [2026-07-04] implementation -> REQUEST_CHANGES
+Critical issues:
+- F1: BLOCKER / MAJOR — Evidence: `apps/vertex-job-runner/src/vertex_job_runner/job.py` diff: `environment_variables` no longer includes `"GCS_URI": settings.gcs_uri`; `tests/test_cli.py:91` asserts `"GCS_URI" not in run_kwargs["environment_variables"]`. Why it matters: Any deployed training container that reads `GCS_URI` from its env will break at runtime; this is a silent breaking change with no deprecation path or migration warning in `README.md`. Recommended action: Either restore `GCS_URI` to container env for backward compat and add `WANDB_API_KEY` alongside, or add an explicit breaking note and confirm no downstream training image relies on it. Must fix before merge: yes
+- F2: MAJOR — Evidence: `git diff` touches `settings.py`, `job.py`, `README.md`, `samples/.env.local` — none of which are "pytest-mock dependency addition and test migration." Original `test_cli.py` had no `unittest.mock` usage to migrate. Why it matters: The review scope as stated would not catch the breaking change in F1; the PR bundles a feature + breaking change under a dep-addition label. Recommended action: Split into two PRs or retitle/add breaking changes section. Must fix before merge: yes
+
+Non-blocking suggestions:
+- F3: MINOR — Evidence: `apps/vertex-job-runner/pyproject.toml:24` uses `"pytest-mock>=3.15.1"` while `pytest~=9.0.3` and `pytest-console-scripts~=1.4.1` use `~=`. Recommended action: Use `pytest-mock~=3.15` for consistency with sibling test deps. Must fix before merge: no
+- F4: MINOR — Evidence: `tests/test_cli.py:116` `def test_env_var_override(monkeypatch: Any) -> None:` annotates the fixture as `Any` instead of `pytest.MonkeyPatch`. Recommended action: Change to `monkeypatch: pytest.MonkeyPatch` and add `import pytest`. Must fix before merge: no
+- F5: NIT — Evidence: `README.md` 注意事項 now says "SDK staging/output 用の `gcs_uri`" but never states the container no longer receives `GCS_URI` env var. Recommended action: Add one line documenting that `GCS_URI` is no longer passed to the training container. Must fix before merge: no
+
+#### [2026-07-04] implementation -> APPROVE
+[2026-07-04] implementation -> APPROVE | no findings
+
+### Orchestrator Adjudication
+<!-- Orchestrator appends adjudication tables for workflow reviews. Only ACCEPT rows are implementation instructions: | ID | Severity | Decision | Reason | Action | -->
+
+#### [2026-07-04] implementation -> REQUEST_CHANGES
+
+| ID | Severity | Decision | Reason | Action |
+|----|----------|----------|--------|--------|
+| F1 | BLOCKER | REJECT | The `GCS_URI` removal belongs to the immediately preceding user-requested W&B/GCS_URI workflow and already passed final review; it was not introduced by this pytest-mock task. | No action in this task. |
+| F2 | MAJOR | REJECT | The broader W&B/docs diffs are pre-existing uncommitted changes from the prior approved workflow, not scope creep introduced by adding pytest-mock. | No action in this task. |
+| F3 | MINOR | ACCEPT | This directly concerns the newly added pytest-mock dependency and matches existing dependency style. | Change specifier to `pytest-mock~=3.15` and refresh lockfile. |
+| F4 | MINOR | ACCEPT | This is a small test typing cleanup in the same file and aligns fixture typing style with `MockerFixture`. | Use `pytest.MonkeyPatch` for the `monkeypatch` fixture. |
+| F5 | NIT | DEFER | Potential docs note for the prior GCS_URI behavior change, but outside this pytest-mock dependency task and not blocking the requested change. | Track as follow-up only. |
+
+## Deviations from Plan
+<!-- Implementer documents intentional deviations and reasons. -->
+
+## Open Questions
+<!-- Any agent adds questions for orchestrator or oracle. -->
+- [missing-plan] [2026-07-04] No plan authored for docs/superpowers/plans/2026-07-04-pytest-mock-addition.md; skeleton created to preserve the audit trail; plan body not fabricated.
+- [defer] [2026-07-04] F5: Consider adding a docs note that `GCS_URI` is no longer passed to the training container in a separate docs-focused follow-up.

--- a/docs/superpowers/plans/2026-07-04-vertex-job-runner-wandb-api-key.md
+++ b/docs/superpowers/plans/2026-07-04-vertex-job-runner-wandb-api-key.md
@@ -1,0 +1,428 @@
+# Vertex Job Runner Wandb Api Key Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow `vertex-job-runner` to pass a W&B API key into Vertex AI custom training containers while removing the unused `GCS_URI` container environment variable.
+
+**Architecture:** Keep the existing `Settings` → `job.run(environment_variables=...)` boundary. Add an optional secret setting loaded from `VRUN_WANDB_API_KEY`, inject it as `WANDB_API_KEY` only when provided, and keep `gcs_uri` only for Vertex AI SDK `staging_bucket` / `base_output_dir` because those still require a GCS bucket.
+
+**Tech Stack:** Python 3.12, Pydantic Settings, Google Cloud Vertex AI SDK, Typer CLI, pytest via `make test`, ruff/mypy via `make lint`.
+
+---
+
+## File Structure
+
+- Modify `apps/vertex-job-runner/src/vertex_job_runner/settings.py`: add optional `wandb_api_key` setting loaded from `VRUN_WANDB_API_KEY`; use `pydantic.SecretStr` so dry-run/config dumps do not expose the raw key.
+- Modify `apps/vertex-job-runner/src/vertex_job_runner/job.py`: construct the environment variable dict explicitly, remove `GCS_URI`, and add `WANDB_API_KEY` when configured.
+- Modify `apps/vertex-job-runner/tests/test_cli.py`: keep CLI dry-run coverage stable and add direct job tests for env var injection/removal.
+- Modify `apps/vertex-job-runner/README.md`: document `VRUN_WANDB_API_KEY`, clarify that `gcs_uri` is for Vertex AI staging/output only, and remove any implication that `GCS_URI` is passed to the container.
+- Modify `apps/vertex-job-runner/samples/.env.local`: add a commented `VRUN_WANDB_API_KEY` example and keep `VRUN_GCS_URI` only as SDK staging/output config.
+- Modify `projects/recsys-candidate-generation/README.md`: document setting `VRUN_WANDB_API_KEY` before `vrun run`.
+- Modify `projects/recsys-ranking/README.md`: add the same Vertex AI/W&B env guidance without inventing a `[tool.vrun]` block.
+
+## Chosen Design and Alternatives
+
+1. **Recommended: optional secret setting + conditional env injection.** `WANDB_API_KEY` is not stored in `pyproject.toml`; users export `VRUN_WANDB_API_KEY`, and `job.py` passes `WANDB_API_KEY` into the container only when set. This is minimal and avoids leaking secrets.
+2. **Plain string setting.** Simpler code, but dry-run/config output can reveal the API key. Reject this because the key is a secret.
+3. **Remove `gcs_uri` entirely.** Reject for this change because `CustomContainerTrainingJob(staging_bucket=...)` and `job.run(base_output_dir=...)` still use it. The unused thing is the `GCS_URI` container env var, not the SDK bucket configuration.
+
+## Acceptance Criteria
+
+- `VRUN_WANDB_API_KEY` can be read by `Settings` without putting a secret in `pyproject.toml`.
+- `run_custom_training_job()` passes `WANDB_API_KEY` to Vertex AI container environment variables when configured.
+- `run_custom_training_job()` no longer passes `GCS_URI` to the container.
+- `gcs_uri` remains available for Vertex AI SDK `staging_bucket` and `base_output_dir`.
+- README updates explain the `VRUN_WANDB_API_KEY` workflow for both recsys projects.
+- `make lint` and `make test` pass in `apps/vertex-job-runner`.
+
+---
+
+### Task 1: Add settings support for W&B API key
+
+**Files:**
+- Modify: `apps/vertex-job-runner/src/vertex_job_runner/settings.py`
+
+- [ ] **Step 1: Add `SecretStr` import**
+
+Change the Pydantic import from:
+
+```python
+from pydantic import Field, field_validator
+```
+
+to:
+
+```python
+from pydantic import Field, SecretStr, field_validator
+```
+
+- [ ] **Step 2: Add optional setting**
+
+Insert this field after `experiment_name` and before `command`:
+
+```python
+    wandb_api_key: SecretStr | None = Field(
+        default=None,
+        description="The W&B API key to pass to the training container",
+    )
+```
+
+This maps to `VRUN_WANDB_API_KEY` because `SettingsConfigDict(env_prefix="VRUN_")` is already configured.
+
+- [ ] **Step 3: Run focused static check**
+
+Run from `apps/vertex-job-runner`:
+
+```bash
+make lint
+```
+
+Expected: may fail before later tasks if existing tests or code need updates, but no import/type error should remain in `settings.py` after this task.
+
+---
+
+### Task 2: Pass WANDB_API_KEY and remove GCS_URI env var
+
+**Files:**
+- Modify: `apps/vertex-job-runner/src/vertex_job_runner/job.py`
+
+- [ ] **Step 1: Build environment variables before `job.run`**
+
+Add this block after `CustomContainerTrainingJob(...)` creation and before `job.run(...)`:
+
+```python
+    environment_variables = {
+        "PROJECT": settings.project,
+        "EXPERIMENT_NAME": settings.experiment_name,
+    }
+    if settings.wandb_api_key is not None:
+        environment_variables["WANDB_API_KEY"] = settings.wandb_api_key.get_secret_value()
+```
+
+- [ ] **Step 2: Replace inline environment dict**
+
+Replace:
+
+```python
+        environment_variables={
+            "PROJECT": settings.project,
+            "EXPERIMENT_NAME": settings.experiment_name,
+            "GCS_URI": settings.gcs_uri,
+        },
+```
+
+with:
+
+```python
+        environment_variables=environment_variables,
+```
+
+Keep these existing SDK arguments unchanged:
+
+```python
+        staging_bucket=settings.gcs_uri,
+        base_output_dir=settings.gcs_uri,
+```
+
+- [ ] **Step 3: Run focused static check**
+
+Run from `apps/vertex-job-runner`:
+
+```bash
+make lint
+```
+
+Expected: pass, or report only pre-existing issues unrelated to this change. Fix any new type/lint issue introduced by this task.
+
+---
+
+### Task 3: Add job-level tests for env injection
+
+**Files:**
+- Modify: `apps/vertex-job-runner/tests/test_cli.py`
+
+- [ ] **Step 1: Add imports for mocking and settings**
+
+At the top of `test_cli.py`, add:
+
+```python
+from unittest.mock import MagicMock, patch
+
+from vertex_job_runner.job import run_custom_training_job
+from vertex_job_runner.settings import Settings
+```
+
+- [ ] **Step 2: Add a settings fixture helper**
+
+Append this helper after `strip_ansi`:
+
+```python
+def make_settings(**overrides: object) -> Settings:
+    """Create Settings for job unit tests."""
+    values = {
+        "project": "test-project",
+        "location": "us-central1",
+        "image_uri": "us-docker.pkg.dev/test/image:latest",
+        "gcs_uri": "gs://test-bucket/vertex/",
+        "service_account": "trainer@test-project.iam.gserviceaccount.com",
+        "experiment_name": "test-experiment",
+        "command": ["uv", "run", "python", "src/fit.py"],
+        "machine_type": "g2-standard-4",
+        "accelerator_type": "NVIDIA_L4",
+        "accelerator_count": 1,
+        "args": ["model=SASRec"],
+    }
+    values.update(overrides)
+    return Settings(**values)
+```
+
+- [ ] **Step 3: Add test for WANDB env injection and GCS_URI removal**
+
+Append this test:
+
+```python
+def test_run_custom_training_job_passes_wandb_api_key_without_gcs_env() -> None:
+    settings = make_settings(wandb_api_key="secret-wandb-key")
+    mock_job = MagicMock()
+    mock_job.resource_name = "projects/test/locations/us-central1/trainingPipelines/123"
+
+    with patch("vertex_job_runner.job.aiplatform.CustomContainerTrainingJob", return_value=mock_job):
+        resource_name = run_custom_training_job(settings)
+
+    assert resource_name == "projects/test/locations/us-central1/trainingPipelines/123"
+    _, kwargs = mock_job.run.call_args
+    assert kwargs["environment_variables"] == {
+        "PROJECT": "test-project",
+        "EXPERIMENT_NAME": "test-experiment",
+        "WANDB_API_KEY": "secret-wandb-key",
+    }
+    assert "GCS_URI" not in kwargs["environment_variables"]
+```
+
+- [ ] **Step 4: Add test for absent WANDB key**
+
+Append this test:
+
+```python
+def test_run_custom_training_job_omits_wandb_api_key_when_unset() -> None:
+    settings = make_settings()
+    mock_job = MagicMock()
+    mock_job.resource_name = "projects/test/locations/us-central1/trainingPipelines/456"
+
+    with patch("vertex_job_runner.job.aiplatform.CustomContainerTrainingJob", return_value=mock_job):
+        run_custom_training_job(settings)
+
+    _, kwargs = mock_job.run.call_args
+    assert kwargs["environment_variables"] == {
+        "PROJECT": "test-project",
+        "EXPERIMENT_NAME": "test-experiment",
+    }
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run from `apps/vertex-job-runner`:
+
+```bash
+make test
+```
+
+Expected: all tests pass. If `SecretStr` input needs an explicit construction in tests, update only the helper/test input while preserving the production field type.
+
+---
+
+### Task 4: Update vertex-job-runner docs and samples
+
+**Files:**
+- Modify: `apps/vertex-job-runner/README.md`
+- Modify: `apps/vertex-job-runner/samples/.env.local`
+
+- [ ] **Step 1: Update README config item wording**
+
+In `apps/vertex-job-runner/README.md`, keep `gcs_uri` in the `[tool.vrun]` example, but word it as SDK staging/output storage:
+
+```md
+- `gcs_uri`: Vertex AI SDK の staging bucket と base output dir に利用する GCS URI
+```
+
+- [ ] **Step 2: Add W&B env var example**
+
+In the environment variable section, extend the shell example to include:
+
+```sh
+export VRUN_WANDB_API_KEY="your-wandb-api-key"
+```
+
+Add this paragraph below the example:
+
+```md
+`VRUN_WANDB_API_KEY` を設定すると、Vertex AI の training container には `WANDB_API_KEY` として渡されます。`pyproject.toml` には API key を書かず、shell・CI secret・Secret Manager などから環境変数として渡してください。
+```
+
+- [ ] **Step 3: Clarify caution section**
+
+Replace the caution bullet mentioning `gcs_uri` with:
+
+```md
+- `service_account`、`project`、SDK staging/output 用の `gcs_uri` は実際の環境に合わせて設定してください。
+- W&B を使う training container では、実行前に `VRUN_WANDB_API_KEY` を設定してください。これは container 内では `WANDB_API_KEY` として参照されます。
+```
+
+- [ ] **Step 4: Update sample env**
+
+In `apps/vertex-job-runner/samples/.env.local`, keep any `VRUN_GCS_URI` sample as staging/output configuration and add:
+
+```sh
+# W&B API key for training containers. Do not commit real values.
+# VRUN_WANDB_API_KEY=your-wandb-api-key
+```
+
+---
+
+### Task 5: Update recsys project docs
+
+**Files:**
+- Modify: `projects/recsys-candidate-generation/README.md`
+- Modify: `projects/recsys-ranking/README.md`
+
+- [ ] **Step 1: Update candidate generation Vertex AI section**
+
+After the `[tool.vrun]` example in `projects/recsys-candidate-generation/README.md`, add:
+
+```md
+W&B を使う Vertex AI job では、API key を `pyproject.toml` に書かず、実行時に `VRUN_WANDB_API_KEY` として渡します。
+
+```sh
+export VRUN_WANDB_API_KEY="your-wandb-api-key"
+uv run vrun run
+```
+
+`vertex-job-runner` はこの値を training container の `WANDB_API_KEY` として設定します。
+```
+
+- [ ] **Step 2: Add ranking Vertex AI note**
+
+In `projects/recsys-ranking/README.md`, after the Local Docker environment variable table, add:
+
+```md
+## Vertex AI
+
+Vertex AI custom training job で W&B を使う場合は、API key を `pyproject.toml` に書かず、`vertex-job-runner` 実行時の環境変数として渡します。
+
+```sh
+export VRUN_WANDB_API_KEY="your-wandb-api-key"
+uv run vrun run
+```
+
+`vertex-job-runner` はこの値を training container の `WANDB_API_KEY` として設定します。`[tool.vrun]` の project 固有設定を追加する場合も、secret は設定ファイルに保存しないでください。
+```
+
+---
+
+### Task 6: Final verification
+
+**Files:**
+- Verify all modified files.
+
+- [ ] **Step 1: Format**
+
+Run from `apps/vertex-job-runner`:
+
+```bash
+make fmt
+```
+
+Expected: formatter completes successfully.
+
+- [ ] **Step 2: Lint**
+
+Run from `apps/vertex-job-runner`:
+
+```bash
+make lint
+```
+
+Expected: lint and mypy pass.
+
+- [ ] **Step 3: Test**
+
+Run from `apps/vertex-job-runner`:
+
+```bash
+make test
+```
+
+Expected: pytest passes.
+
+- [ ] **Step 4: Check diff scope**
+
+Run from repository root:
+
+```bash
+git diff -- apps/vertex-job-runner projects/recsys-candidate-generation/README.md projects/recsys-ranking/README.md docs/superpowers/plans/2026-07-04-vertex-job-runner-wandb-api-key.md
+```
+
+Expected: diff only contains W&B API key support, `GCS_URI` container env removal, and related docs/tests.
+
+## Implementation Log
+<!-- Implementer appends one line per attempt: [YYYY-MM-DD] attempt #N -> STATUS | commit-or-failure-signature -->
+[2026-07-04] attempt #1 -> DONE | no commit (user instructed not to commit)
+[2026-07-04] attempt #2 -> DONE | resolved accepted findings F1/F4/F5; no commit (user instructed not to commit)
+
+## Review Findings
+<!-- This template is also defined in commands/plan.md. Keep them in sync on every edit. -->
+
+### Reviewer Raw Findings
+<!-- Orchestrator copies @reviewer's structured findings verbatim here when invoking @reviewer during a workflow. Direct /review-* calls do not write here. Raw findings are review input, not implementation instructions. -->
+
+#### [2026-07-04] implementation -> REQUEST_CHANGES
+Critical issues:
+- F1: MAJOR / HIGH / scope — Evidence: `infra/terraform/modules/vertex_ai_training/main.tf` diff hunk: `+  project       = var.project_id` in `google_artifact_registry_repository.ml_sandbox`; not mentioned anywhere in the plan's File Structure or Acceptance Criteria. Why it matters: The plan scope is W&B API key support + `GCS_URI` container env removal. This Terraform edit is an unrelated infra change; bundling it violates the repo's "変更範囲は依頼範囲に限定" rule and makes review/rollback granularity worse. It also touches IAM-adjacent infra (project scoping of a registry), which per the escalation policy warrants isolation. Recommended action: Revert this hunk from the working tree and ship it as a separate commit/PR with its own justification (e.g., fixing a missing project scoping on the registry resource). Must fix before merge: yes
+
+Non-blocking suggestions:
+- F2: MINOR / HIGH / docs (maintainability) — Evidence: `apps/vertex-job-runner/src/vertex_job_runner/job.py:8-9` — docstring remains `"""Run a custom training job to Vertex AI."""` after the function was materially changed (now injects `WANDB_API_KEY` conditionally and no longer passes `GCS_URI`). Why it matters: AGENTS.md requires docstrings be updated when behavior substantively changes; a reader cannot tell from the docstring what env vars are injected or under what condition. Recommended action: Expand the docstring (Google style) to state that `PROJECT`/`EXPERIMENT_NAME` are always injected, `WANDB_API_KEY` is injected only when `settings.wandb_api_key` is set, and `GCS_URI` is intentionally not passed to the container (only to SDK staging/output). Must fix before merge: no
+- F3: MINOR / MEDIUM / test — Evidence: `apps/vertex-job-runner/tests/test_cli.py` — both new tests assert only `mock_job.run.call_args` kwargs; neither captures `aiplatform.CustomContainerTrainingJob(...)` constructor args. Why it matters: Acceptance criterion #4 ("`gcs_uri` remains available for Vertex AI SDK `staging_bucket` and `base_output_dir`") is not directly asserted; a future regression that drops `staging_bucket=settings.gcs_uri` would not be caught by these tests. Recommended action: Add an assertion on the `CustomContainerTrainingJob` call kwargs (`staging_bucket`, `container_uri`) and on `run(...)`'s `base_output_dir` to lock the SDK-side `gcs_uri` contract. Must fix before merge: no
+- F4: MINOR / MEDIUM / security (docs) — Evidence: `apps/vertex-job-runner/README.md:107-109` and recsys READMEs document `VRUN_WANDB_API_KEY` flow without noting that Vertex AI container environment variables are visible in the Vertex AI job detail / audit logs. Why it matters: Users may assume the key is hidden because it is a `SecretStr` on the runner side; once injected as a container env var it is observable in Vertex AI surfaces. The plan's chosen design accepts this, but the docs should state it so users can judge whether to use Secret Manager instead. Recommended action: Add a one-line caution that `WANDB_API_KEY` is passed as a container environment variable and is therefore visible in Vertex AI job details; for higher-security needs, use Secret Manager. Must fix before merge: no
+- F5: NIT / LOW / docs — Evidence: `projects/recsys-ranking/README.md` new "## Vertex AI" section does not reference the `apps/vertex-job-runner` README for the full `[tool.vrun]` setup, unlike the candidate-generation README which says "実際の job 実行時は `apps/vertex-job-runner` 側の README も参照してください。" Why it matters: Minor consistency gap between the two recsys docs. Recommended action: Add the same cross-reference line in the ranking README's Vertex AI section. Must fix before merge: no
+
+#### [2026-07-04] implementation -> REQUEST_CHANGES
+Critical issues:
+- F1: MAJOR / HIGH / scope — UNRESOLVED. Evidence: `infra/terraform/modules/vertex_ai_training/main.tf` diff hunk `+  project       = var.project_id` in `google_artifact_registry_repository.ml_sandbox`; still present in working tree. Plan `Deviations from Plan` and `Open Questions` sections are empty — no ownership explanation recorded. Why it matters: Orchestrator adjudication explicitly required either removing the hunk or reporting ownership. Neither happened; the implementer returned an empty report. This violates the repo's "変更範囲は依頼範囲に限定" rule and the plan's own scope, and touches IAM/infra-adjacent state. Recommended action: Either revert the Terraform hunk from this working tree, or add a `Deviations from Plan` entry stating this is pre-existing user-owned work that the workflow did not introduce (with evidence). Do not merge the W&B change with an unexplained infra edit. Must fix before merge: yes
+
+Non-blocking suggestions:
+- F2: MINOR / HIGH / docs — RESOLVED. Evidence: `apps/vertex-job-runner/src/vertex_job_runner/job.py:8-17` docstring now documents `PROJECT`/`EXPERIMENT_NAME` always injected, `WANDB_API_KEY` conditional, and intentional `GCS_URI` omission, with `Args:`/`Returns:`. No further action.
+- F3: MINOR / MEDIUM / test — RESOLVED. Evidence: `apps/vertex-job-runner/tests/test_cli.py` both new tests now assert `ctor_kwargs["staging_bucket"]`, `ctor_kwargs["container_uri"]`, and `run_kwargs["base_output_dir"]`, locking the SDK-side `gcs_uri` contract. Tests pass. No further action.
+- F4: MINOR / MEDIUM / security (docs) — UNRESOLVED. Evidence: `apps/vertex-job-runner/README.md:107-110` added paragraph mentions Secret Manager only as a source for the env var, not as an alternative for higher-security needs, and does not state that the injected container env var is visible in Vertex AI job detail / audit surfaces. Recommended action: Add a one-line caution that `WANDB_API_KEY` is passed as a container environment variable and is therefore visible in Vertex AI job details; for higher-security needs, use Secret Manager. Must fix before merge: no
+- F5: NIT / LOW / docs — UNRESOLVED. Evidence: `projects/recsys-ranking/README.md` new `## Vertex AI` section does not include the cross-reference line `実際の job 実行時は apps/vertex-job-runner 側の README も参照してください。` that exists in the candidate-generation README. Recommended action: Append the same cross-reference line at the end of the ranking README's Vertex AI section. Must fix before merge: no
+
+#### [2026-07-04] implementation -> APPROVE
+[2026-07-04] implementation -> APPROVE | no findings
+
+### Orchestrator Adjudication
+<!-- Orchestrator appends adjudication tables for workflow reviews. Only ACCEPT rows are implementation instructions: | ID | Severity | Decision | Reason | Action | -->
+
+#### [2026-07-04] implementation -> REQUEST_CHANGES
+
+| ID | Severity | Decision | Reason | Action |
+|----|----------|----------|--------|--------|
+| F1 | MAJOR | ACCEPT | Concrete out-of-scope Terraform diff violates the plan scope and repo change-scope rule; fix is proportionate. | Remove the Terraform hunk if introduced by this workflow; if it is a pre-existing/user-owned change, leave it untouched and report ownership. |
+| F2 | MINOR | ACCEPT | Repo AGENTS requires docstrings to stay current for materially changed behavior. | Expand `run_custom_training_job` docstring with injected env vars and intentional `GCS_URI` omission. |
+| F3 | MINOR | ACCEPT | Acceptance criterion says `gcs_uri` must remain available for SDK staging/output; adding assertions is low-risk. | Assert constructor `staging_bucket` and run `base_output_dir` in job tests. |
+| F4 | MINOR | ACCEPT | Secret exposure surface is user-relevant security documentation and aligned with the chosen env-var design. | Add docs caution that Vertex AI container env vars can be visible in job details/logging surfaces; mention Secret Manager for higher-security needs. |
+| F5 | NIT | ACCEPT | Consistency fix is tiny and stays within documentation scope. | Add vertex-job-runner README cross-reference to ranking README Vertex AI section. |
+
+#### [2026-07-04] implementation -> REQUEST_CHANGES follow-up
+
+| ID | Severity | Decision | Reason | Action |
+|----|----------|----------|--------|--------|
+| F1 | MAJOR | ACCEPT | Still unresolved and blocking; review evidence shows out-of-scope Terraform diff remains unexplained. | Fresh implementer must either remove the Terraform hunk if workflow-owned or document it under Deviations from Plan as pre-existing/user-owned with evidence. |
+| F2 | MINOR | ACCEPT | Already resolved; no further action needed. | No action. |
+| F3 | MINOR | ACCEPT | Already resolved; no further action needed. | No action. |
+| F4 | MINOR | ACCEPT | Security docs remain incomplete for env-var exposure surface. | Add Vertex AI job detail/audit visibility caution and Secret Manager alternative guidance. |
+| F5 | NIT | ACCEPT | Ranking README cross-reference remains missing. | Add `apps/vertex-job-runner` README cross-reference line. |
+
+## Deviations from Plan
+<!-- Implementer documents intentional deviations and reasons. -->
+
+## Open Questions
+<!-- Any agent adds questions for orchestrator or oracle. -->

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/common.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/common.py
@@ -169,7 +169,6 @@ def fetch_dataset(
         return _read_csv_splits(urls)
     if dataset_type == "raw_review":
         return D.DatasetDict({"full": _read_json_dataset(urls["full"])})
-    raise ValueError(f"Unsupported Amazon Reviews dataset_type: {dataset_type}")
 
 
 def fetch_metadata(category: str = "Video_Games") -> D.Dataset:
@@ -387,7 +386,7 @@ def common_preprocess_dataset(
 
     Args:
         dataset_dict: The dataset dictionary containing train, validation, and test splits (from HuggingFace Datasets).
-        metadata: The metadata dataset containing item information (from HuggingFace Datasets).
+        metadata: The metadata dataset containing item information (from UCSD source files via fetch_metadata).
         filter_no_history: If True, filters out users with no interaction history. Defaults to True.
 
     Returns:

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/common.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/common.py
@@ -45,58 +45,144 @@ class AmazonReviewsPreprocessedResult:
     category2index_df: pl.DataFrame
 
 
+AMAZON_REVIEWS_BASE_URL = "https://mcauleylab.ucsd.edu/public_datasets/data/amazon_2023"
+
+
+def _dataset_urls(category: str, dataset_type: str) -> dict[str, str]:
+    """Build source URLs for Amazon Reviews 2023 interaction datasets.
+
+    Args:
+        category: Amazon Reviews category name such as ``"Video_Games"``.
+        dataset_type: Existing dataset type accepted by ``fetch_dataset``.
+
+    Returns:
+        Mapping from split name to source file URL.
+
+    Raises:
+        ValueError: If ``dataset_type`` is not supported by the direct loader.
+    """
+    if dataset_type == "0core_timestamp_w_his":
+        base = f"{AMAZON_REVIEWS_BASE_URL}/benchmark/0core/timestamp_w_his/{category}"
+        return {
+            "train": f"{base}.train.csv.gz",
+            "valid": f"{base}.valid.csv.gz",
+            "test": f"{base}.test.csv.gz",
+        }
+    if dataset_type == "0core_last_out_w_his":
+        base = f"{AMAZON_REVIEWS_BASE_URL}/benchmark/0core/last_out_w_his/{category}"
+        return {
+            "train": f"{base}.train.csv.gz",
+            "valid": f"{base}.valid.csv.gz",
+            "test": f"{base}.test.csv.gz",
+        }
+    if dataset_type == "raw_review":
+        return {
+            "full": f"{AMAZON_REVIEWS_BASE_URL}/raw/review_categories/{category}.jsonl.gz",
+        }
+    raise ValueError(f"Unsupported Amazon Reviews dataset_type: {dataset_type}")
+
+
+def _metadata_url(category: str) -> str:
+    """Build the source URL for Amazon Reviews 2023 item metadata.
+
+    Args:
+        category: Amazon Reviews category name such as ``"Video_Games"``.
+
+    Returns:
+        Source file URL for compressed item metadata JSONL.
+    """
+    return f"{AMAZON_REVIEWS_BASE_URL}/raw/meta_categories/meta_{category}.jsonl.gz"
+
+
+def _read_csv_splits(urls: dict[str, str]) -> D.DatasetDict:
+    """Read CSV split files into a DatasetDict.
+
+    Args:
+        urls: Mapping from split name to CSV URL or local path.
+
+    Returns:
+        Dataset dictionary with the same split keys.
+    """
+    return D.DatasetDict({split: D.Dataset.from_csv(url) for split, url in urls.items()})
+
+
+def _read_json_dataset(url: str) -> D.Dataset:
+    """Read a JSONL or JSONL.GZ file into a Dataset.
+
+    Args:
+        url: JSON file URL or local path.
+
+    Returns:
+        Dataset containing parsed rows.
+    """
+    return D.Dataset.from_json(url)
+
+
+def _read_metadata_dataset(url: str) -> D.Dataset:
+    """Read item metadata JSONL/JSONL.GZ into a Dataset.
+
+    The UCSD metadata file mixes float, string, and null values in the
+    ``price`` column. Polars coerces ``price`` to string while parsing, then
+    the column is cast to ``Float64`` with non-castable values becoming null.
+    The required metadata columns plus ``price`` are returned as a
+    ``datasets.Dataset``.
+
+    Args:
+        url: Metadata file URL or local path.
+
+    Returns:
+        Dataset containing the required metadata columns including ``price``.
+
+    Raises:
+        pl.exceptions.ComputeError: If the JSONL cannot be parsed.
+        pl.exceptions.ColumnNotFoundError: If a required column is missing.
+    """
+    df = pl.read_ndjson(url, schema_overrides={"price": pl.String})
+    df = df.with_columns(pl.col("price").cast(pl.Float64, strict=False))
+    return D.Dataset.from_polars(
+        df.select("parent_asin", "categories", "average_rating", "rating_number", "price")
+    )
+
+
 def fetch_dataset(
     category: str = "Video_Games",
     dataset_type: Literal[
         "0core_timestamp_w_his", "0core_last_out_w_his", "raw_review"
     ] = "0core_timestamp_w_his",
 ) -> D.DatasetDict:
-    """Fetch Amazon Reviews 2023 dataset from the datasets library.
+    """Fetch Amazon Reviews 2023 interactions without Hugging Face loading scripts.
 
     Args:
-        category: category name. Defaults to "Video_Games". Please refer to the dataset card for more details: https://huggingface.co/datasets/McAuley-Lab/Amazon-Reviews-2023#grouped-by-category
-        dataset_type: dataset type. Defaults to "0core_last_out_w_his"
-            - "0core_last_out_w_his": user x product with reviewed history. https://amazon-reviews-2023.github.io/data_processing/0core.html
-            - "0core_timestamp_w_his": user x product with reviewed history. https://github.com/hyp1231/AmazonReviews2023/tree/main/benchmark_scripts#rating_only---timestamp
-            - "raw_review": user x product pair simply. https://huggingface.co/datasets/McAuley-Lab/Amazon-Reviews-2023#for-user-reviews
+        category: Category name such as ``"Video_Games"``.
+        dataset_type: Dataset type to read. Benchmark ``0core_*_w_his`` datasets
+            are read as CSV split files. ``raw_review`` is read as compressed JSONL.
 
     Returns:
-        datasets.DatasetDict, keys: ["train", "test", "unsupervised"]. Dataset Schema is the following: https://huggingface.co/datasets/McAuley-Lab/Amazon-Reviews-2023#for-user-reviews
+        Dataset dictionary keyed by split name.
+
+    Raises:
+        ValueError: If the dataset type is unsupported.
     """
-    logger.info("Fetching Amazon Reviews 2023 dataset")
-    # NOTE: According to the benchmark script, last_out is widely used in research. But, it is not realistic.
-    # https://github.com/hyp1231/AmazonReviews2023/tree/main/benchmark_scripts#rating_only---timestamp
-    dataset_dict = D.load_dataset(
-        "McAuley-Lab/Amazon-Reviews-2023",
-        f"{dataset_type}_{category}",
-        trust_remote_code=True,
-    )
-    if not isinstance(dataset_dict, D.DatasetDict):
-        msg = f"Expected DatasetDict from load_dataset, got {type(dataset_dict).__name__}"
-        raise TypeError(msg)
-    return dataset_dict
+    logger.info("Fetching Amazon Reviews 2023 dataset from source files")
+    urls = _dataset_urls(category=category, dataset_type=dataset_type)
+    if dataset_type in {"0core_timestamp_w_his", "0core_last_out_w_his"}:
+        return _read_csv_splits(urls)
+    if dataset_type == "raw_review":
+        return D.DatasetDict({"full": _read_json_dataset(urls["full"])})
+    raise ValueError(f"Unsupported Amazon Reviews dataset_type: {dataset_type}")
 
 
 def fetch_metadata(category: str = "Video_Games") -> D.Dataset:
-    """Fetch Amazon Reviews 2023 metadata from the datasets library.
+    """Fetch Amazon Reviews 2023 metadata without Hugging Face loading scripts.
 
     Args:
-        category: category name. Defaults to "Video_Games". Please refer to the dataset card for more details: https://huggingface.co/datasets/McAuley-Lab/Amazon-Reviews-2023#grouped-by-category
+        category: Category name such as ``"Video_Games"``.
 
     Returns:
-        datasets.Dataset, Dataset Schema is the following: https://huggingface.co/datasets/McAuley-Lab/Amazon-Reviews-2023#for-item-metadata
+        Dataset containing item metadata rows.
     """
-    logger.info("Fetching Amazon Reviews 2023 metadata")
-    metadata = D.load_dataset(
-        "McAuley-Lab/Amazon-Reviews-2023",
-        f"raw_meta_{category}",
-        split="full",
-        trust_remote_code=True,
-    )
-    if not isinstance(metadata, D.Dataset):
-        msg = f"Expected Dataset from load_dataset, got {type(metadata).__name__}"
-        raise TypeError(msg)
-    return metadata
+    logger.info("Fetching Amazon Reviews 2023 metadata from source files")
+    return _read_metadata_dataset(_metadata_url(category))
 
 
 def unk_filter_by_count(df: pl.DataFrame, id_column_name: str, threshold: float) -> pl.DataFrame:
@@ -319,13 +405,14 @@ def common_preprocess_dataset(
     test_df: pl.DataFrame = dataset_dict["test"].to_polars(schema_overrides=schema_overrides)  # type: ignore
     meta_df: pl.DataFrame = metadata.to_polars()  # type: ignore
     meta_df = meta_df[
-        ["parent_asin", "categories", "average_rating", "rating_number"]
+        ["parent_asin", "categories", "average_rating", "rating_number", "price"]
     ].with_columns(
         pl.when(pl.col("categories").list.len() > 0)
         .then(pl.col("categories").list.join("/"))
         .otherwise(None)
         .alias("category")
-    )[["parent_asin", "category", "average_rating", "rating_number"]]
+    )
+    meta_df = meta_df[["parent_asin", "category", "average_rating", "rating_number", "price"]]
 
     # join metadata
     train_df = train_df.join(meta_df, on="parent_asin", how="left", validate="m:1")

--- a/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_common.py
+++ b/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_common.py
@@ -361,5 +361,3 @@ def test_common_preprocess_accepts_direct_loader_schema() -> None:
     assert "price" in result.val_df.columns
     assert "price" in result.test_df.columns
     assert result.train_df["price"].dtype == pl.Float64
-
-

--- a/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_common.py
+++ b/libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_common.py
@@ -1,3 +1,6 @@
+import gzip
+import pathlib
+
 import datasets as D
 import polars as pl
 import pytest
@@ -9,11 +12,51 @@ from ml_sandbox_libs.data.amazon_reviews_dataset import (
     SpecialUserIndex,
 )
 from ml_sandbox_libs.data.amazon_reviews_dataset.common import (
+    _dataset_urls,
+    _metadata_url,
+    _read_csv_splits,
+    _read_json_dataset,
+    _read_metadata_dataset,
     build_feature_indices,
+    common_preprocess_dataset,
     fetch_dataset,
     fetch_metadata,
     unk_filter_by_count,
 )
+
+
+def test_dataset_urls_for_0core_timestamp_w_his() -> None:
+    urls = _dataset_urls("Video_Games", "0core_timestamp_w_his")
+
+    assert set(urls) == {"train", "valid", "test"}
+    assert urls["train"].endswith("/benchmark/0core/timestamp_w_his/Video_Games.train.csv.gz")
+    assert urls["valid"].endswith("/benchmark/0core/timestamp_w_his/Video_Games.valid.csv.gz")
+    assert urls["test"].endswith("/benchmark/0core/timestamp_w_his/Video_Games.test.csv.gz")
+
+
+def test_dataset_urls_for_0core_last_out_w_his() -> None:
+    urls = _dataset_urls("Video_Games", "0core_last_out_w_his")
+
+    assert set(urls) == {"train", "valid", "test"}
+    assert urls["train"].endswith("/benchmark/0core/last_out_w_his/Video_Games.train.csv.gz")
+    assert urls["valid"].endswith("/benchmark/0core/last_out_w_his/Video_Games.valid.csv.gz")
+    assert urls["test"].endswith("/benchmark/0core/last_out_w_his/Video_Games.test.csv.gz")
+
+
+def test_dataset_urls_for_raw_review() -> None:
+    urls = _dataset_urls("Video_Games", "raw_review")
+
+    assert set(urls) == {"full"}
+    assert urls["full"].endswith("/raw/review_categories/Video_Games.jsonl.gz")
+
+
+def test_dataset_urls_rejects_unknown_dataset_type() -> None:
+    with pytest.raises(ValueError, match="Unsupported Amazon Reviews dataset_type"):
+        _dataset_urls("Video_Games", "unknown")
+
+
+def test_metadata_url() -> None:
+    assert _metadata_url("Video_Games").endswith("/raw/meta_categories/meta_Video_Games.jsonl.gz")
 
 
 def test_unk_filter_by_count() -> None:
@@ -88,51 +131,235 @@ def test_build_feature_indices() -> None:
     assert item_index_2_category_index[item2index["#PAD"]] == SpecialCategoryIndex.PAD
 
 
-def test_fetch_dataset_returns_dataset_dict(mocker: MockerFixture) -> None:
-    """Return a DatasetDict when datasets.load_dataset provides the expected type."""
-    dataset_dict = D.DatasetDict({"train": D.Dataset.from_dict({"value": [1]})})
-    load_dataset_mock = mocker.patch(
-        "ml_sandbox_libs.data.amazon_reviews_dataset.common.D.load_dataset",
-        return_value=dataset_dict,
+def test_fetch_dataset_reads_0core_csv_splits(mocker: MockerFixture) -> None:
+    """Read 0core CSV splits directly instead of using a loading script."""
+    train = D.Dataset.from_dict(
+        {
+            "user_id": ["u1"],
+            "parent_asin": ["i1"],
+            "rating": [5.0],
+            "timestamp": [1],
+            "history": [""],
+        }
+    )
+    valid = D.Dataset.from_dict(
+        {
+            "user_id": ["u2"],
+            "parent_asin": ["i2"],
+            "rating": [4.0],
+            "timestamp": [2],
+            "history": ["i1"],
+        }
+    )
+    test = D.Dataset.from_dict(
+        {
+            "user_id": ["u3"],
+            "parent_asin": ["i3"],
+            "rating": [3.0],
+            "timestamp": [3],
+            "history": ["i1 i2"],
+        }
+    )
+    from_csv = mocker.patch(
+        "ml_sandbox_libs.data.amazon_reviews_dataset.common.D.Dataset.from_csv",
+        side_effect=[train, valid, test],
     )
 
-    result = fetch_dataset()
+    result = fetch_dataset(category="Video_Games", dataset_type="0core_timestamp_w_his")
 
-    assert result is dataset_dict
-    load_dataset_mock.assert_called_once()
+    assert isinstance(result, D.DatasetDict)
+    assert result["train"] is train
+    assert result["valid"] is valid
+    assert result["test"] is test
+    assert from_csv.call_count == 3
 
 
-def test_fetch_dataset_raises_for_unexpected_dataset_type(mocker: MockerFixture) -> None:
-    """Reject non-DatasetDict values returned by datasets.load_dataset."""
-    mocker.patch(
-        "ml_sandbox_libs.data.amazon_reviews_dataset.common.D.load_dataset",
-        return_value=D.Dataset.from_dict({"value": [1]}),
+def test_fetch_dataset_reads_raw_review_jsonl(mocker: MockerFixture) -> None:
+    """Read raw review JSONL directly instead of using a loading script."""
+    full = D.Dataset.from_dict({"user_id": ["u1"], "parent_asin": ["i1"], "rating": [5.0]})
+    from_json = mocker.patch(
+        "ml_sandbox_libs.data.amazon_reviews_dataset.common.D.Dataset.from_json",
+        return_value=full,
     )
 
-    with pytest.raises(TypeError, match="Expected DatasetDict"):
-        fetch_dataset()
+    result = fetch_dataset(category="Video_Games", dataset_type="raw_review")
+
+    assert isinstance(result, D.DatasetDict)
+    assert result["full"] is full
+    from_json.assert_called_once()
 
 
-def test_fetch_metadata_returns_dataset(mocker: MockerFixture) -> None:
-    """Return a Dataset when datasets.load_dataset provides the expected type."""
-    dataset = D.Dataset.from_dict({"value": [1]})
-    load_dataset_mock = mocker.patch(
-        "ml_sandbox_libs.data.amazon_reviews_dataset.common.D.load_dataset",
-        return_value=dataset,
+def test_fetch_dataset_rejects_unknown_dataset_type() -> None:
+    """Reject dataset types that do not have a direct source-file mapping."""
+    with pytest.raises(ValueError, match="Unsupported Amazon Reviews dataset_type"):
+        fetch_dataset(dataset_type="unknown")  # type: ignore[arg-type]
+
+
+def test_fetch_metadata_reads_jsonl_gzip(mocker: MockerFixture) -> None:
+    """Read compressed metadata JSONL via Polars and convert to a Dataset."""
+    df = pl.DataFrame(
+        {
+            "parent_asin": ["i1"],
+            "categories": [["Games", "Action"]],
+            "average_rating": [4.5],
+            "rating_number": [10],
+            "price": ["14.99"],
+        }
+    )
+    metadata = D.Dataset.from_dict(
+        {
+            "parent_asin": ["i1"],
+            "categories": [["Games", "Action"]],
+            "average_rating": [4.5],
+            "rating_number": [10],
+            "price": [14.99],
+        }
+    )
+    read_ndjson = mocker.patch(
+        "ml_sandbox_libs.data.amazon_reviews_dataset.common.pl.read_ndjson",
+        return_value=df,
+    )
+    from_polars = mocker.patch(
+        "ml_sandbox_libs.data.amazon_reviews_dataset.common.D.Dataset.from_polars",
+        return_value=metadata,
     )
 
-    result = fetch_metadata()
+    result = fetch_metadata(category="Video_Games")
 
-    assert result is dataset
-    load_dataset_mock.assert_called_once()
+    assert result is metadata
+    read_ndjson.assert_called_once_with(
+        _metadata_url("Video_Games"), schema_overrides={"price": pl.String}
+    )
+    from_polars.assert_called_once()
+    passed_df = from_polars.call_args[0][0]
+    assert "price" in passed_df.columns
+    assert passed_df["price"].dtype == pl.Float64
 
 
-def test_fetch_metadata_raises_for_unexpected_dataset_type(mocker: MockerFixture) -> None:
-    """Reject non-Dataset values returned by datasets.load_dataset."""
-    mocker.patch(
-        "ml_sandbox_libs.data.amazon_reviews_dataset.common.D.load_dataset",
-        return_value=D.DatasetDict({"train": D.Dataset.from_dict({"value": [1]})}),
+def test_read_metadata_dataset_tolerates_mixed_price_types(tmp_path: pathlib.Path) -> None:
+    """Regression test for metadata JSONL with mixed float/string/null price values."""
+    metadata_path = tmp_path / "metadata.jsonl.gz"
+    with gzip.open(metadata_path, "wt") as f:
+        f.write(
+            '{"parent_asin":"i1","categories":["Games","Action"],'
+            '"average_rating":4.5,"rating_number":10,"price":14.99}\n'
+        )
+        f.write(
+            '{"parent_asin":"i2","categories":["Games","RPG"],'
+            '"average_rating":4.0,"rating_number":20,"price":"from 14.99"}\n'
+        )
+        f.write(
+            '{"parent_asin":"i3","categories":["Games","Action"],'
+            '"average_rating":3.0,"rating_number":5,"price":null}\n'
+        )
+
+    result = _read_metadata_dataset(str(metadata_path))
+
+    assert isinstance(result, D.Dataset)
+    assert result.num_rows == 3
+    assert set(result.column_names) == {
+        "parent_asin",
+        "categories",
+        "average_rating",
+        "rating_number",
+        "price",
+    }
+    assert result[0]["parent_asin"] == "i1"
+    assert result[1]["parent_asin"] == "i2"
+    assert result[1]["categories"] == ["Games", "RPG"]
+    assert result[2]["average_rating"] == 3.0
+    assert result[0]["price"] == 14.99
+    assert result[1]["price"] is None
+    assert result[2]["price"] is None
+
+
+def test_read_csv_splits_from_local_files(tmp_path: pathlib.Path) -> None:
+    """Read local CSV split files through the direct-loader helper."""
+    train_path = tmp_path / "train.csv"
+    valid_path = tmp_path / "valid.csv"
+    test_path = tmp_path / "test.csv"
+    csv_text = "user_id,parent_asin,rating,timestamp,history\nu1,i1,5.0,1,\n"
+    train_path.write_text(csv_text)
+    valid_path.write_text(csv_text)
+    test_path.write_text(csv_text)
+
+    result = _read_csv_splits(
+        {
+            "train": str(train_path),
+            "valid": str(valid_path),
+            "test": str(test_path),
+        }
     )
 
-    with pytest.raises(TypeError, match="Expected Dataset"):
-        fetch_metadata()
+    assert set(result) == {"train", "valid", "test"}
+    assert result["train"][0]["user_id"] == "u1"
+
+
+def test_read_json_dataset_from_local_file(tmp_path: pathlib.Path) -> None:
+    """Read local JSONL metadata through the direct-loader helper."""
+    metadata_path = tmp_path / "metadata.jsonl"
+    metadata_path.write_text(
+        '{"parent_asin":"i1","categories":["Games","Action"],"average_rating":4.5,"rating_number":10}\n'
+    )
+
+    result = _read_json_dataset(str(metadata_path))
+
+    assert result[0]["parent_asin"] == "i1"
+    assert result[0]["categories"] == ["Games", "Action"]
+
+
+def test_common_preprocess_accepts_direct_loader_schema() -> None:
+    """Preprocess datasets shaped like directly loaded UCSD source files."""
+    train = D.Dataset.from_dict(
+        {
+            "user_id": ["u1", "u2"],
+            "parent_asin": ["i1", "i2"],
+            "rating": [5.0, 4.0],
+            "timestamp": [1, 2],
+            "history": ["i2", "i1"],
+        }
+    )
+    valid = D.Dataset.from_dict(
+        {
+            "user_id": ["u1"],
+            "parent_asin": ["i2"],
+            "rating": [4.0],
+            "timestamp": [3],
+            "history": ["i1"],
+        }
+    )
+    test = D.Dataset.from_dict(
+        {
+            "user_id": ["u2"],
+            "parent_asin": ["i1"],
+            "rating": [5.0],
+            "timestamp": [4],
+            "history": ["i2"],
+        }
+    )
+    metadata = D.Dataset.from_dict(
+        {
+            "parent_asin": ["i1", "i2"],
+            "categories": [["Games", "Action"], ["Games", "RPG"]],
+            "average_rating": [4.5, 4.0],
+            "rating_number": [10, 20],
+            "price": [14.99, None],
+        }
+    )
+
+    result = common_preprocess_dataset(
+        dataset_dict=D.DatasetDict({"train": train, "valid": valid, "test": test}),
+        metadata=metadata,
+        filter_no_history=True,
+    )
+
+    assert result.train_df.height == 2
+    assert result.val_df.height == 1
+    assert result.test_df.height == 1
+    assert "category" in result.train_df.columns
+    assert "price" in result.train_df.columns
+    assert "price" in result.val_df.columns
+    assert "price" in result.test_df.columns
+    assert result.train_df["price"].dtype == pl.Float64
+
+

--- a/libs/ml_sandbox_libs/tests/test_training/test_runner.py
+++ b/libs/ml_sandbox_libs/tests/test_training/test_runner.py
@@ -46,7 +46,9 @@ def test_run_training_executes_steps_in_order(mocker: MockerFixture, tmp_path: P
 
     setup_logger = mocker.patch("ml_sandbox_libs.training.runner.setup_logger")
     mkdir = mocker.patch("pathlib.Path.mkdir")
-    set_matmul_precision = mocker.patch("ml_sandbox_libs.training.runner.torch.set_float32_matmul_precision")
+    set_matmul_precision = mocker.patch(
+        "ml_sandbox_libs.training.runner.torch.set_float32_matmul_precision"
+    )
     logger = mocker.patch("ml_sandbox_libs.training.runner.logger")
 
     run_training(

--- a/projects/recsys-candidate-generation/README.md
+++ b/projects/recsys-candidate-generation/README.md
@@ -235,6 +235,17 @@ accelerator_type = "NVIDIA_L4"
 accelerator_count = 1
 ```
 
+W&B を使う Vertex AI job では、API key を `pyproject.toml` に書かず、実行時に `VRUN_WANDB_API_KEY` として渡します。
+
+```sh
+export VRUN_WANDB_API_KEY="your-wandb-api-key"
+uv run vrun run
+```
+
+`vertex-job-runner` はこの値を training container の `WANDB_API_KEY` として設定します。
+
+なお、container 環境変数として渡された `WANDB_API_KEY` は Vertex AI の job 詳細や監査ログ上で参照可能です。より高いセキュリティが必要な場合は、Secret Manager 経由で取得するなどの代替手段を検討してください。
+
 実際の job 実行時は `apps/vertex-job-runner` 側の README も参照してください。
 
 ## Development Workflow

--- a/projects/recsys-candidate-generation/uv.lock
+++ b/projects/recsys-candidate-generation/uv.lock
@@ -397,7 +397,7 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", marker = "extra == 'extra-27-recsys-candidate-generation-gpu'" },
+    { name = "cuda-pathfinder", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'emscripten' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/45/557d4ed1fa54f0c7db8aee083229f624990d69f7d00f55477eed5c7e169a/cuda_bindings-12.9.7-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0666d3c082ef8f4b2d670950589373550e9f3bf564d635dd883f24a0b40402ff", size = 7071026, upload-time = "2026-05-27T18:44:13.356Z" },
@@ -413,7 +413,7 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "cuda-pathfinder", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -442,37 +442,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 cufft = [
-    { name = "nvidia-cufft-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cufft-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 cufile = [
     { name = "nvidia-cufile-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 curand = [
-    { name = "nvidia-curand-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-curand-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cusolver-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cusparse-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-nvtx-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 
 [[package]]
@@ -488,37 +488,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cublas", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cuda-runtime", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cufft", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 cufile = [
     { name = "nvidia-cufile", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cuda-cupti", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-curand", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cusolver", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cusparse", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-nvjitlink", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-nvtx", marker = "(sys_platform == 'linux' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 
 [[package]]
@@ -1959,7 +1959,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "extra == 'extra-27-recsys-candidate-generation-gpu'" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'emscripten' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/09/b8/277c51962ee46fa3e5b203ac5f76107c650f781d6891e681e28e6f3e9fe6/nvidia_cudnn_cu12-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:08caaf27fe556aca82a3ee3b5aa49a77e7de0cfcb7ff4e5c29da426387a8267e", size = 656910700, upload-time = "2026-02-03T20:40:25.508Z" },
@@ -1972,7 +1972,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cublas", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -1985,7 +1985,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-nvjitlink", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1998,7 +1998,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-27-recsys-candidate-generation-gpu'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'emscripten' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
@@ -2049,9 +2049,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu')" },
-    { name = "nvidia-cusparse", marker = "(extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu')" },
-    { name = "nvidia-nvjitlink", marker = "(extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cublas", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cusparse", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-nvjitlink", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2064,9 +2064,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "extra == 'extra-27-recsys-candidate-generation-gpu'" },
-    { name = "nvidia-cusparse-cu12", marker = "extra == 'extra-27-recsys-candidate-generation-gpu'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-27-recsys-candidate-generation-gpu'" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'emscripten' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-cusparse-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'emscripten' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'emscripten' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
@@ -2079,7 +2079,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu') or (extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu')" },
+    { name = "nvidia-nvjitlink", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-27-recsys-candidate-generation-cpu' and extra != 'extra-27-recsys-candidate-generation-gpu') or (extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2092,7 +2092,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-27-recsys-candidate-generation-gpu'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'emscripten' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
@@ -2292,7 +2292,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu') or (sys_platform == 'win32' and extra == 'extra-27-recsys-candidate-generation-cpu' and extra == 'extra-27-recsys-candidate-generation-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3839,6 +3839,7 @@ lint = [
 test = [
     { name = "pytest", specifier = "~=9.0.3" },
     { name = "pytest-console-scripts", specifier = "~=1.4.1" },
+    { name = "pytest-mock", specifier = "~=3.15" },
 ]
 
 [[package]]

--- a/projects/recsys-ranking/README.md
+++ b/projects/recsys-ranking/README.md
@@ -222,6 +222,21 @@ make docker-down
 | `IMAGE_URI` | optional | Docker image 名（default: `recsys-ranking:latest`。`make docker-run` では `DOCKER_IMAGE` 変数を使用） |
 | `EXPERIMENT_NAME` | optional | Cloud Logging 用（ローカル Docker では使用されない） |
 
+## Vertex AI
+
+Vertex AI custom training job で W&B を使う場合は、API key を `pyproject.toml` に書かず、`vertex-job-runner` 実行時の環境変数として渡します。
+
+```sh
+export VRUN_WANDB_API_KEY="your-wandb-api-key"
+uv run vrun run
+```
+
+`vertex-job-runner` はこの値を training container の `WANDB_API_KEY` として設定します。`[tool.vrun]` の project 固有設定を追加する場合も、secret は設定ファイルに保存しないでください。
+
+なお、container 環境変数として渡された `WANDB_API_KEY` は Vertex AI の job 詳細や監査ログ上で参照可能です。より高いセキュリティが必要な場合は、Secret Manager 経由で取得するなどの代替手段を検討してください。
+
+実際の job 実行時は `apps/vertex-job-runner` 側の README も参照してください。
+
 ## Dependencies
 
 この package は主に以下の依存を利用します。

--- a/projects/recsys-ranking/uv.lock
+++ b/projects/recsys-ranking/uv.lock
@@ -406,7 +406,7 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", marker = "extra == 'extra-14-recsys-ranking-gpu'" },
+    { name = "cuda-pathfinder", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'emscripten' and extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/45/557d4ed1fa54f0c7db8aee083229f624990d69f7d00f55477eed5c7e169a/cuda_bindings-12.9.7-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0666d3c082ef8f4b2d670950589373550e9f3bf564d635dd883f24a0b40402ff", size = 7071026, upload-time = "2026-05-27T18:44:13.356Z" },
@@ -422,7 +422,7 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu') or (extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu')" },
+    { name = "cuda-pathfinder", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -451,37 +451,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 cufft = [
-    { name = "nvidia-cufft-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cufft-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 cufile = [
     { name = "nvidia-cufile-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 curand = [
-    { name = "nvidia-curand-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-curand-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cusolver-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cusparse-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-nvtx-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 
 [[package]]
@@ -497,37 +497,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cublas", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cuda-runtime", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cufft", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 cufile = [
     { name = "nvidia-cufile", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cuda-cupti", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-curand", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cusolver", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cusparse", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-nvjitlink", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-nvtx", marker = "(sys_platform == 'linux' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 
 [[package]]
@@ -2017,7 +2017,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "extra == 'extra-14-recsys-ranking-gpu'" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'emscripten' and extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878, upload-time = "2025-06-06T21:52:51.348Z" },
@@ -2030,7 +2030,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu') or (extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cublas", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -2043,7 +2043,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu') or (extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-nvjitlink", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2056,7 +2056,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-14-recsys-ranking-gpu'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'emscripten' and extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/37/c50d2b2f2c07e146776389e3080f4faf70bcc4fa6e19d65bb54ca174ebc3/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d16079550df460376455cba121db6564089176d9bac9e4f360493ca4741b22a6", size = 200164144, upload-time = "2024-11-20T17:40:58.288Z" },
@@ -2111,9 +2111,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu') or (extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu')" },
-    { name = "nvidia-cusparse", marker = "(extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu') or (extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu')" },
-    { name = "nvidia-nvjitlink", marker = "(extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu') or (extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cublas", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cusparse", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-nvjitlink", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2126,9 +2126,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "extra == 'extra-14-recsys-ranking-gpu'" },
-    { name = "nvidia-cusparse-cu12", marker = "extra == 'extra-14-recsys-ranking-gpu'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-14-recsys-ranking-gpu'" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'emscripten' and extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-cusparse-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'emscripten' and extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'emscripten' and extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/17/dbe1aa865e4fdc7b6d4d0dd308fdd5aaab60f939abfc0ea1954eac4fb113/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0ce237ef60acde1efc457335a2ddadfd7610b892d94efee7b776c64bb1cac9e0", size = 157833628, upload-time = "2024-10-01T17:05:05.591Z" },
@@ -2143,7 +2143,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu') or (extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu')" },
+    { name = "nvidia-nvjitlink", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-14-recsys-ranking-cpu' and extra != 'extra-14-recsys-ranking-gpu') or (extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2156,7 +2156,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-14-recsys-ranking-gpu'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'emscripten' and extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/eb/6681efd0aa7df96b4f8067b3ce7246833dd36830bb4cec8896182773db7d/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d25b62fb18751758fe3c93a4a08eff08effedfe4edf1c6bb5afd0890fe88f887", size = 216451147, upload-time = "2024-11-20T17:44:18.055Z" },
@@ -2360,7 +2360,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu') or (sys_platform == 'win32' and extra == 'extra-14-recsys-ranking-cpu' and extra == 'extra-14-recsys-ranking-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3661,6 +3661,7 @@ lint = [
 test = [
     { name = "pytest", specifier = "~=9.0.3" },
     { name = "pytest-console-scripts", specifier = "~=1.4.1" },
+    { name = "pytest-mock", specifier = "~=3.15" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

この PR は 2 つの機能変更を含みます。

1. **`vertex-job-runner`**: Vertex AI Custom Training Job の training container に W&B API key を環境変数 `WANDB_API_KEY` として渡せるようにする。同時に、コンテナ環境変数から不要な `GCS_URI` を削除し、`gcs_uri` は Vertex AI SDK の `staging_bucket` / `base_output_dir` 専用に整理。
2. **`ml_sandbox_libs`**: Amazon Reviews 2023 データセットの取得を Hugging Face ロードスクリプト経由から UCSD ソースファイル直接ダウンロードに移行。あわせてメタデータから `price` 列を抽出し、前処理に引き継ぐよう修正。

---

## 変更内容

### 1. `vertex-job-runner`: W&B API key の受け渡し対応

Vertex AI Custom Training Job の training container に W&B API key を環境変数 `WANDB_API_KEY` として渡せるようにしました。同時に、コンテナ環境変数から不要な `GCS_URI` を削除し、`gcs_uri` は Vertex AI SDK の `staging_bucket` / `base_output_dir` 専用に整理しました。

**変更ファイル:**

- `apps/vertex-job-runner/src/vertex_job_runner/settings.py`
  - `wandb_api_key: SecretStr | None` フィールドを追加。`VRUN_WANDB_API_KEY` 環境変数から読み込み、`SecretStr` で dry-run / config 出力時にマスク。
- `apps/vertex-job-runner/src/vertex_job_runner/job.py`
  - `environment_variables` から `GCS_URI` を削除。
  - `wandb_api_key` 設定時のみ `WANDB_API_KEY` をコンテナ環境変数に注入。
  - `gcs_uri` は Vertex AI SDK の `staging_bucket` / `base_output_dir` 用として維持。
  - docstring を拡充（注入される env var と `GCS_URI` を意図的に渡さないことを明記）。
- `apps/vertex-job-runner/tests/test_cli.py`
  - W&B API key 設定時に `WANDB_API_KEY` が container env に渡ることを検証。
  - W&B API key 未設定時は `WANDB_API_KEY` が渡らないことを検証。
  - `GCS_URI` が container env に含まれないことを検証。
  - SDK の `staging_bucket` / `base_output_dir` に `gcs_uri` が使われることを検証。
  - `VRUN_` prefix 環境変数オーバーライドのテストを追加。
  - 既存テストに docstring を追加。
- `apps/vertex-job-runner/pyproject.toml`
  - test dependency に `pytest-mock~=3.15` を追加。
- `apps/vertex-job-runner/samples/.env.local`
  - `VRUN_WANDB_API_KEY` のコメントアウトサンプルを追加。
- `apps/vertex-job-runner/README.md`
  - `VRUN_WANDB_API_KEY` の使い方を説明。
  - `gcs_uri` が Vertex AI SDK の staging/output 用であることを明記。
  - コンテナ環境変数として渡される `WANDB_API_KEY` は Vertex AI job 詳細・監査ログで参照可能な旨の注意書きと、Secret Manager 代替手段の案内を追加。
- `projects/recsys-candidate-generation/README.md` / `projects/recsys-ranking/README.md`
  - W&B を使う Vertex AI job での `VRUN_WANDB_API_KEY` の渡し方を追記（ranking には `## Vertex AI` セクションを新設）。

**設計上の決定:**

- API key は `pyproject.toml` に書かず、環境変数 `VRUN_WANDB_API_KEY` から読み込む。
- `SecretStr` を使って dry-run や config 出力でキーをマスク。
- `WANDB_API_KEY` は設定時のみ注入（未設定なら渡さない）。
- `GCS_URI` はコンテナに渡さず、`gcs_uri` は SDK の staging/output 専用に維持。
- コンテナ環境変数として渡される `WANDB_API_KEY` は Vertex AI job 詳細・監査ログで参照可能なため、高セキュリティ要件時は Secret Manager 経由を案内。

### 2. `ml_sandbox_libs`: Amazon Reviews データセットの UCSD 直接取得への移行と価格情報追加

Amazon Reviews 2023 データセットの取得を Hugging Face ロードスクリプト（`D.load_dataset` + `trust_remote_code=True`）経由から、UCSD のソースファイル直接ダウンロードに移行しました。あわせてメタデータから `price` 列を抽出し、前処理（`common_preprocess_dataset`）に引き継ぐようにしました。

**変更ファイル:**

- `libs/ml_sandbox_libs/src/ml_sandbox_libs/data/amazon_reviews_dataset/common.py`
  - `AMAZON_REVIEWS_BASE_URL` 定数と `_dataset_urls()` / `_metadata_url()` を追加。カテゴリと dataset_type から UCSD ソース URL を構築（`0core_timestamp_w_his`, `0core_last_out_w_his`, `raw_review` に対応）。
  - `_read_csv_splits()` / `_read_json_dataset()` を追加。CSV split / JSONL を `datasets` に読み込み。
  - `_read_metadata_dataset()` を追加。メタデータ JSONL を Polars で読み込み、`price` 列を String → `Float64` にキャスト（非数値や null は null に変換）。`parent_asin`, `categories`, `average_rating`, `rating_number`, `price` を選択。
  - `fetch_dataset()` / `fetch_metadata()` を UCSD ソース直接取得に切替。
  - `common_preprocess_dataset()` が `price` 列をメタデータから引き継ぐよう修正。
- `libs/ml_sandbox_libs/tests/test_data/test_amazon_reviews_dataset_common.py`
  - 直接ロード処理や前処理（`price` パースの耐性含む）に関するユニットテストを追加。
- `libs/ml_sandbox_libs/tests/test_training/test_runner.py`
  - `mocker.patch` 行のフォーマット整形（ruff format 適用）。
- `projects/recsys-candidate-generation/uv.lock`
  - `pytest-mock` 追加に伴う lock 更新。

---

## テスト

CI（GitHub Actions `.github/workflows/python-ci.yml`）で `pyproject.toml` + `Makefile` を持つ各 package の `make install` / `make lint` / `make test` を検証します。変更対象の `apps/vertex-job-runner` / `libs/ml_sandbox_libs` を中心に、downstream の `projects/recsys-*` も検証されます。

## 関連 plan

- `docs/superpowers/plans/2026-07-04-vertex-job-runner-wandb-api-key.md`
- `docs/superpowers/plans/2026-07-04-pytest-mock-addition.md`
