### PR TITLE
fix: resolve ruff 0.16 lint violations for minor-patch dependency update

### DIFF
--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/models/modules/feature_embedding_dict.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/models/modules/feature_embedding_dict.py
@@ -57,7 +57,7 @@ class FeatureEmbeddingDict(nn.Module):
         elif isinstance(existing_encoder, nn.Linear):
             existing_dims = existing_encoder.out_features
         else:
-            raise ValueError(f"Unknown encoder type: {type(existing_encoder)}")
+            raise TypeError(f"Unknown encoder type: {type(existing_encoder)}")
 
         if existing_dims != feature_spec.embedding_dims:
             raise ValueError(

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/models/modules/mlp.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/models/modules/mlp.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from typing import Any
 
 import torch
-import torch.nn as nn
+from torch import nn
 
 from ml_sandbox_libs.models.types import ActivationType, LinearOpOrderType, NormalizeType
 

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/optimizer/adam_w_cosine.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/optimizer/adam_w_cosine.py
@@ -4,9 +4,9 @@ from collections.abc import Iterator
 from typing import Any
 
 import torch
-import torch.nn as nn
 from lightning.pytorch.utilities.types import LRSchedulerConfigType, OptimizerLRSchedulerConfig
 from timm.scheduler.cosine_lr import CosineLRScheduler
+from torch import nn
 
 from ml_sandbox_libs.optimizer.types import LRSchedulerParams
 

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/optimizer/base.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/optimizer/base.py
@@ -3,8 +3,8 @@
 from collections.abc import Iterator
 from typing import Any, Protocol, runtime_checkable
 
-import torch.nn as nn
 from lightning.pytorch.utilities.types import OptimizerLRSchedulerConfig
+from torch import nn
 
 
 @runtime_checkable

--- a/libs/ml_sandbox_libs/src/ml_sandbox_libs/utils/utils.py
+++ b/libs/ml_sandbox_libs/src/ml_sandbox_libs/utils/utils.py
@@ -2,7 +2,7 @@ import os
 from typing import Any
 
 import torch
-import torch.nn as nn
+from torch import nn
 
 
 def create_attn_padding_mask(

--- a/libs/ml_sandbox_libs/tests/test_optimizer.py
+++ b/libs/ml_sandbox_libs/tests/test_optimizer.py
@@ -5,9 +5,9 @@ from typing import Any, cast
 
 import pytest
 import torch
-import torch.nn as nn
 from lightning.pytorch.utilities.types import OptimizerLRSchedulerConfig
 from pytest_mock import MockerFixture
+from torch import nn
 
 from ml_sandbox_libs.optimizer import AdamWCosine, Optimizer
 from ml_sandbox_libs.optimizer.types import LRSchedulerParams

--- a/projects/recsys-candidate-generation/src/fit.py
+++ b/projects/recsys-candidate-generation/src/fit.py
@@ -1,5 +1,5 @@
 import pathlib
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import cast
 
 import hydra
@@ -34,7 +34,7 @@ def create_trainer(cfg: DictConfig, save_dir: pathlib.Path) -> L.Trainer:
         project="recsys-candidate-generation",
         name=cfg.model.name,
         save_dir=save_dir / "logs",
-        version=f"{cfg.model.name}_{datetime.now().strftime('%Y%m%dT%H%M%S')}",
+        version=f"{cfg.model.name}_{datetime.now(tz=UTC).strftime('%Y%m%dT%H%M%S')}",
     )
 
     devices = [cfg.device.accelerator_no] if cfg.device.accelerator == "gpu" else "auto"

--- a/projects/recsys-candidate-generation/src/fit.py
+++ b/projects/recsys-candidate-generation/src/fit.py
@@ -1,6 +1,7 @@
 import pathlib
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import cast
+from zoneinfo import ZoneInfo
 
 import hydra
 import lightning as L
@@ -34,7 +35,7 @@ def create_trainer(cfg: DictConfig, save_dir: pathlib.Path) -> L.Trainer:
         project="recsys-candidate-generation",
         name=cfg.model.name,
         save_dir=save_dir / "logs",
-        version=f"{cfg.model.name}_{datetime.now(tz=UTC).strftime('%Y%m%dT%H%M%S')}",
+        version=f"{cfg.model.name}_{datetime.now(tz=ZoneInfo('Asia/Tokyo')).strftime('%Y%m%dT%H%M%S')}",
     )
 
     devices = [cfg.device.accelerator_no] if cfg.device.accelerator == "gpu" else "auto"

--- a/projects/recsys-candidate-generation/src/tests/test_data/test_data_factory.py
+++ b/projects/recsys-candidate-generation/src/tests/test_data/test_data_factory.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 import pytest
 from omegaconf import OmegaConf
 
-import data.factory as factory
+from data import factory
 
 
 def _create_cfg(model_name: str) -> Any:

--- a/projects/recsys-candidate-generation/src/tests/test_models/test_factory.py
+++ b/projects/recsys-candidate-generation/src/tests/test_models/test_factory.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 import pytest
 from omegaconf import OmegaConf
 
-import models.factory as factory
+from models import factory
 
 
 @pytest.mark.parametrize(

--- a/projects/recsys-ranking/src/fit.py
+++ b/projects/recsys-ranking/src/fit.py
@@ -1,5 +1,5 @@
 import pathlib
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import cast
 
 import hydra
@@ -32,7 +32,7 @@ def create_trainer(cfg: DictConfig, save_dir: pathlib.Path) -> L.Trainer:
         project="recsys-ranking",
         name=cfg.model.name,
         save_dir=save_dir / "logs",
-        version=f"{cfg.model.name}_{datetime.now().strftime('%Y%m%dT%H%M%S')}",
+        version=f"{cfg.model.name}_{datetime.now(tz=UTC).strftime('%Y%m%dT%H%M%S')}",
     )
 
     devices = [cfg.device.accelerator_no] if cfg.device.accelerator == "gpu" else "auto"

--- a/projects/recsys-ranking/src/fit.py
+++ b/projects/recsys-ranking/src/fit.py
@@ -1,6 +1,7 @@
 import pathlib
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import cast
+from zoneinfo import ZoneInfo
 
 import hydra
 import lightning as L
@@ -32,7 +33,7 @@ def create_trainer(cfg: DictConfig, save_dir: pathlib.Path) -> L.Trainer:
         project="recsys-ranking",
         name=cfg.model.name,
         save_dir=save_dir / "logs",
-        version=f"{cfg.model.name}_{datetime.now(tz=UTC).strftime('%Y%m%dT%H%M%S')}",
+        version=f"{cfg.model.name}_{datetime.now(tz=ZoneInfo('Asia/Tokyo')).strftime('%Y%m%dT%H%M%S')}",
     )
 
     devices = [cfg.device.accelerator_no] if cfg.device.accelerator == "gpu" else "auto"

--- a/projects/recsys-ranking/src/models/modules/cross_net.py
+++ b/projects/recsys-ranking/src/models/modules/cross_net.py
@@ -15,9 +15,9 @@ Reference:
 from typing import Any, cast
 
 import torch
-import torch.nn as nn
 from ml_sandbox_libs.models.modules.base import build_activation, build_normalization
 from ml_sandbox_libs.models.types import ActivationType, NormalizeType
+from torch import nn
 
 
 def _build_cross_activation(

--- a/projects/recsys-ranking/src/tests/test_models/test_dcnv2.py
+++ b/projects/recsys-ranking/src/tests/test_models/test_dcnv2.py
@@ -11,13 +11,13 @@ from models.dcnv2 import DCNv2
 
 @pytest.fixture
 def base_params() -> dict[str, Any]:
-    return dict(
-        num_items=1000,
-        feature_embedding_dims=32,
-        cross_num_layers=2,
-        deep_hidden_dims=[64, 32],
-        item_pad_idx=0,
-    )
+    return {
+        "num_items": 1000,
+        "feature_embedding_dims": 32,
+        "cross_num_layers": 2,
+        "deep_hidden_dims": [64, 32],
+        "item_pad_idx": 0,
+    }
 
 
 @pytest.fixture

--- a/projects/recsys-ranking/src/tests/test_models/test_factory.py
+++ b/projects/recsys-ranking/src/tests/test_models/test_factory.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 import pytest
 from omegaconf import OmegaConf
 
-import models.factory as factory
+from models import factory
 
 
 def _build_cfg() -> Any:

--- a/projects/sentiment_analysis/models/classifier.py
+++ b/projects/sentiment_analysis/models/classifier.py
@@ -1,6 +1,6 @@
 import lightning as L
 import torch
-import torch.nn as nn
+from torch import nn
 from torch.optim import Adam, Optimizer
 from torchmetrics.classification import BinaryAccuracy
 

--- a/projects/sentiment_analysis/models/modules/base/attention.py
+++ b/projects/sentiment_analysis/models/modules/base/attention.py
@@ -1,8 +1,8 @@
 from math import sqrt
 
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
+from torch import nn
 
 
 def scaled_dot_product_attention(

--- a/projects/sentiment_analysis/models/transformer.py
+++ b/projects/sentiment_analysis/models/transformer.py
@@ -1,5 +1,5 @@
 import torch
-import torch.nn as nn
+from torch import nn
 
 from utils import create_cross_attention_mask, create_self_attention_mask
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR #176（minor-patch グループ更新）で `ruff` が 0.16.0 に上がった際に CI が落ちていた lint エラーを修正します。

## Changes

| Rule | Fix |
|---|---|
| `PLR0402` | `import torch.nn as nn` → `from torch import nn` |
| `PLR0402` | `import data.factory as factory` → `from data import factory` |
| `TRY004` | 未知の encoder 型に対して `ValueError` → `TypeError` |
| `DTZ005` | `datetime.now()` → `datetime.now(tz=ZoneInfo("Asia/Tokyo"))`（JST） |
| `C408` | `dict(...)` → dict リテラル |

## Affected packages

- `libs/ml_sandbox_libs`
- `projects/recsys-ranking`
- `projects/recsys-candidate-generation`
- `projects/sentiment_analysis`

## Verification

各 package で `make lint` / `make test` を実行済みです。加えて `uvx ruff==0.16.0 check` で対象ファイルの lint 通過を確認しています。

## Follow-up

この PR マージ後、PR #176（ruff 0.16.0 を含む minor-patch グループ更新）の rebase / CI 再実行で依存関係更新を進められます。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc8d7-2586-7650-8cd0-0594cc93ef00?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc8d7-2586-7650-8cd0-0594cc93ef00&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

